### PR TITLE
feat: support importing scores from clipboard exported by MMBL

### DIFF
--- a/apps/web/src/components/rating/io/ImportMenu.tsx
+++ b/apps/web/src/components/rating/io/ImportMenu.tsx
@@ -6,7 +6,8 @@ import { ImportFromAquaSQLiteListItem } from './import/ImportFromAquaSQLiteListI
 import { ImportFromDivingFishButtonListItem } from './import/ImportFromDivingFishButtonListItem'
 import { ImportFromJSONButtonListItem } from './import/ImportFromJSONButtonListItem'
 import { ImportFromNETRecordsListItem } from './import/ImportFromNETRecordsListItem'
-import {ImportFromAquaDxButtonListItem} from "./import/ImportFromAquaDxButtonListItem.tsx";
+import { ImportFromAquaDxButtonListItem } from './import/ImportFromAquaDxButtonListItem'
+import { ImportFromMMBLExportListItem } from './import/ImportFromMMBLExportListItem'
 
 export const ImportMenu: FC<{
   modifyEntries: ListActions<PlayEntry>
@@ -49,6 +50,7 @@ export const ImportMenu: FC<{
       >
         <ImportFromNETRecordsListItem modifyEntries={modifyEntries} onClose={handleClose} />
         <ImportFromDivingFishButtonListItem modifyEntries={modifyEntries} onClose={handleClose} />
+        <ImportFromMMBLExportListItem modifyEntries={modifyEntries} onClose={handleClose} />
 
         <Divider />
 

--- a/apps/web/src/components/rating/io/import/ImportFromMMBLExportListItem.tsx
+++ b/apps/web/src/components/rating/io/import/ImportFromMMBLExportListItem.tsx
@@ -84,7 +84,7 @@ export const ImportFromMMBLExportListItem: FC<{
       <ListItemIcon>
         <MdiClipboardText />
       </ListItemIcon>
-      <ListItemText>Import from MMBL Export...</ListItemText>
+      <ListItemText>Import from MMBL exported data (clipboard)...</ListItemText>
     </MenuItem>
   )
 }

--- a/apps/web/src/components/rating/io/import/ImportFromMMBLExportListItem.tsx
+++ b/apps/web/src/components/rating/io/import/ImportFromMMBLExportListItem.tsx
@@ -1,0 +1,90 @@
+import { ListItemIcon, ListItemText, MenuItem } from '@mui/material'
+import MdiClipboardText from '~icons/mdi/clipboard-text'
+import type { FC } from 'react'
+import toast from 'react-hot-toast'
+import type { ListActions } from 'react-use/lib/useList'
+import type { PlayEntry } from '../../RatingCalculatorAddEntryForm'
+
+const EXPECTED_HEADER = 'Song\tGenre\tVersion\tChart\tDifficulty\tLevel\tAchv\tRank\tFC/AP\tSync\tDX ✦\tDX %'
+
+export const ImportFromMMBLExportListItem: FC<{
+  modifyEntries: ListActions<PlayEntry>
+  onClose: () => void
+}> = ({ modifyEntries, onClose }) => {
+  const parseAchievement = (achievement: string): number => {
+    const value = parseFloat(achievement.replace('%', ''))
+    return isNaN(value) ? 0 : value / 100
+  }
+
+  return (
+    <MenuItem
+      onClick={async () => {
+        onClose()
+        
+        try {
+          const text = await navigator.clipboard.readText()
+          if (!text) {
+            toast.error('No data in clipboard')
+            return
+          }
+
+          const lines = text.trim().split('\n')
+          
+          // Validate header line
+          if (!lines[0] || lines[0].trim() !== EXPECTED_HEADER) {
+            toast.error('Invalid MMBL export format')
+            return
+          }
+
+          const musicIdMapJson = await import('@/assets/music-id-map.json')
+          const musicIdMap: { [key: string]: { name: string; ver: string } } =
+            musicIdMapJson.default
+
+          const entries: PlayEntry[] = []
+          
+          // Process data rows
+          for (let i = 1; i < lines.length; i++) {
+            const row = lines[i].split('\t')
+            if (row.length !== 12) {
+              toast.error('Invalid line found in MMBL export')
+              continue
+            }
+
+            const [songName, , , chartType, difficulty, , achievement] = row
+            
+            // Skip if missing required fields
+            if (!songName || !chartType || !difficulty || !achievement) {
+              toast.error('Invalid line found in MMBL export')
+              continue
+            }
+
+            // Find song in music ID map
+            const songEntry = Object.entries(musicIdMap).find(
+              ([, song]) => song.name === songName
+            )
+
+            if (!songEntry || songEntry[1].ver === '24000') continue
+
+            const type = chartType === 'DX' ? '__dxrt__dx__dxrt__' : '__dxrt__std__dxrt__'
+            const sheetId = `${songName}${type}${difficulty.toLowerCase()}`
+            
+            entries.push({
+              sheetId,
+              achievementRate: parseAchievement(achievement)
+            })
+          }
+
+          modifyEntries.set(entries)
+          toast.success(`Imported ${entries.length} entries`)
+        } catch (error) {
+          toast.error(`Failed to import: ${error instanceof Error ? error.message : 'Unknown error'}`)
+        }
+      }}
+    >
+      <ListItemIcon>
+        <MdiClipboardText />
+      </ListItemIcon>
+      <ListItemText>Import from MMBL Export...</ListItemText>
+    </MenuItem>
+  )
+}

--- a/apps/web/src/components/rating/io/import/ImportFromMMBLExportListItem.tsx
+++ b/apps/web/src/components/rating/io/import/ImportFromMMBLExportListItem.tsx
@@ -63,7 +63,7 @@ export const ImportFromMMBLExportListItem: FC<{
               ([, song]) => song.name === songName
             )
 
-            if (!songEntry || songEntry[1].ver === '24000') continue
+            if (!songEntry) continue
 
             const type = chartType === 'DX' ? '__dxrt__dx__dxrt__' : '__dxrt__std__dxrt__'
             const sheetId = `${songName}${type}${difficulty.toLowerCase()}`


### PR DESCRIPTION
this
![image](https://github.com/user-attachments/assets/19afd87a-654a-431d-a1a3-474d36037e94)

（然后写完了才发现 MMBL 的 Rating Calculator 已经支持了导出成 DXRating.net 格式。。。
![image](https://github.com/user-attachments/assets/640f3563-df02-4725-a405-531b4c82721d)
but anyways，可以省一步导出（）