### PR TITLE
Support sheet search by internal ID

### DIFF
--- a/apps/web/src/songs.ts
+++ b/apps/web/src/songs.ts
@@ -147,7 +147,33 @@ export const useSheetsSearchEngine = () => {
     )
   }, [songs, serverAliases])
 
+  const sheetsByInternalId = useMemo(() => {
+    const map = new Map<number, FlattenedSheet[]>()
+
+    for (const sheet of sheets ?? []) {
+      if (sheet.internalId === undefined) {
+        continue
+      }
+
+      const existing = map.get(sheet.internalId) ?? []
+      existing.push(sheet)
+      map.set(sheet.internalId, existing)
+    }
+
+    return map
+  }, [sheets])
+
   const search = (term: string) => {
+    const trimmedTerm = term.trim()
+
+    if (/^\d+$/.test(trimmedTerm)) {
+      const targetInternalId = Number.parseInt(trimmedTerm, 10)
+
+      if (!Number.isNaN(targetInternalId)) {
+        return sheetsByInternalId.get(targetInternalId) ?? []
+      }
+    }
+
     const results = fuseInstance.search(term)
     return results.flatMap((result) => {
       return sheets?.filter((sheet) => sheet.songId === result.item.songId) ?? []


### PR DESCRIPTION
## Summary
- memoize a lookup map of sheets by internal ID
- return matching sheets immediately when the search term is a numeric internal ID

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de7b94668c8330ac8daf5d636502bd