### PR TITLE
feat: add AP/AP+ rating bonus (+1) for CiRCLE era

### DIFF
--- a/apps/web/src/components/rating/RatingCalculatorAddEntryForm.tsx
+++ b/apps/web/src/components/rating/RatingCalculatorAddEntryForm.tsx
@@ -27,7 +27,7 @@ export interface PlayEntryProviderConfig {
   }
 }
 
-export type ComboFlag = 'fc' | 'fcp' | 'ap' | 'app' | null
+export type { ComboFlag } from '../../utils/rating'
 export type SyncFlag = 'fs' | 'fsp' | 'fsd' | 'fsdp' | 'sync' | null
 
 export interface PlayEntry {

--- a/apps/web/src/components/rating/useRatingEntries.tsx
+++ b/apps/web/src/components/rating/useRatingEntries.tsx
@@ -80,7 +80,7 @@ export const useRatingEntries = (): UseRatingEntriesReturn => {
         {
           ...entry,
           sheet,
-          rating: sheet.isRatingEligible ? calculateRating(sheet.internalLevelValue, entry.achievementRate) : null,
+          rating: sheet.isRatingEligible ? calculateRating(sheet.internalLevelValue, entry.achievementRate, entry.comboFlag) : null,
         },
       ]
     })

--- a/apps/web/src/utils/__tests__/rating.test.ts
+++ b/apps/web/src/utils/__tests__/rating.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { calculateB50, calculateRating, type RatingEntry, SCORE_COEFFICIENT_TABLE } from '../rating'
+import { calculateB50, calculateRating, type ComboFlag, type RatingEntry, SCORE_COEFFICIENT_TABLE } from '../rating'
 
 describe('calculateRating', () => {
   describe('rank thresholds', () => {
@@ -195,6 +195,44 @@ describe('calculateRating', () => {
   })
 })
 
+describe('AP/AP+ bonus', () => {
+  it('AP grants +1 rating bonus', () => {
+    const without = calculateRating(14.0, 100.5)
+    const withAp = calculateRating(14.0, 100.5, 'ap')
+    expect(withAp.ratingAwardValue).toBe(without.ratingAwardValue + 1)
+  })
+
+  it('AP+ grants +1 rating bonus', () => {
+    const without = calculateRating(14.0, 100.5)
+    const withApp = calculateRating(14.0, 100.5, 'app')
+    expect(withApp.ratingAwardValue).toBe(without.ratingAwardValue + 1)
+  })
+
+  it.each([null, 'fc', 'fcp'] as ComboFlag[])('comboFlag %s does NOT grant bonus', (flag) => {
+    const without = calculateRating(14.0, 100.5)
+    const withFlag = calculateRating(14.0, 100.5, flag)
+    expect(withFlag.ratingAwardValue).toBe(without.ratingAwardValue)
+  })
+
+  it('undefined comboFlag does NOT grant bonus', () => {
+    const without = calculateRating(14.0, 100.5)
+    const withUndefined = calculateRating(14.0, 100.5, undefined)
+    expect(withUndefined.ratingAwardValue).toBe(without.ratingAwardValue)
+  })
+
+  it('AP bonus applies after floor truncation', () => {
+    // floor(22.4 × 14.0 × 100.5 / 100) = floor(315.168) = 315, +1 = 316
+    const result = calculateRating(14.0, 100.5, 'ap')
+    expect(result.ratingAwardValue).toBe(316)
+  })
+
+  it('AP bonus applies even at 0% achievement', () => {
+    const result = calculateRating(14.0, 0, 'ap')
+    // base is 0, +1 = 1
+    expect(result.ratingAwardValue).toBe(1)
+  })
+})
+
 describe('calculateB50', () => {
   const currentVersionIds = new Set(['song-a', 'song-b', 'song-c'])
 
@@ -280,5 +318,15 @@ describe('calculateB50', () => {
     const result = calculateB50(new Set(), entries)
     expect(result.b15).toHaveLength(0)
     expect(result.b35).toHaveLength(2)
+  })
+
+  it('includes AP bonus in b50 rating total', () => {
+    const entries: RatingEntry[] = [
+      { id: 'song-a', internalLevel: 14.0, achievementRate: 100.5, comboFlag: 'ap' }, // b15: 315 + 1 = 316
+      { id: 'old-1', internalLevel: 13.0, achievementRate: 100.5, comboFlag: 'app' }, // b35: 292 + 1 = 293
+    ]
+
+    const result = calculateB50(currentVersionIds, entries)
+    expect(result.b50Rating).toBe(316 + 293)
   })
 })

--- a/apps/web/src/utils/rating.ts
+++ b/apps/web/src/utils/rating.ts
@@ -35,6 +35,7 @@ export interface RatingEntry {
   id: string
   internalLevel: number
   achievementRate: number
+  comboFlag?: ComboFlag
 }
 
 export interface RatedEntry extends RatingEntry {
@@ -55,7 +56,7 @@ export interface B50Result {
 export const calculateB50 = (currentVersionIds: Set<string>, entries: RatingEntry[]): B50Result => {
   const rated: RatedEntry[] = entries.map((entry) => ({
     ...entry,
-    rating: calculateRating(entry.internalLevel, entry.achievementRate),
+    rating: calculateRating(entry.internalLevel, entry.achievementRate, entry.comboFlag),
   }))
 
   const byRatingDesc = (a: RatedEntry, b: RatedEntry) => b.rating.ratingAwardValue - a.rating.ratingAwardValue
@@ -77,12 +78,15 @@ export const calculateB50 = (currentVersionIds: Set<string>, entries: RatingEntr
   return { b15, b35, b50Rating }
 }
 
-export const calculateRating = (internalLevel: number, achievementRate: number): Rating => {
+export type ComboFlag = 'fc' | 'fcp' | 'ap' | 'app' | null
+
+export const calculateRating = (internalLevel: number, achievementRate: number, comboFlag?: ComboFlag): Rating => {
   for (let i = 0; i < SCORE_COEFFICIENT_TABLE.length; i++) {
     if (i === SCORE_COEFFICIENT_TABLE.length - 1 || achievementRate < SCORE_COEFFICIENT_TABLE[i + 1][0]) {
       const coefficient = SCORE_COEFFICIENT_TABLE[i][1]
+      const apBonus = comboFlag === 'ap' || comboFlag === 'app' ? 1 : 0
       return {
-        ratingAwardValue: Math.floor((coefficient * internalLevel * Math.min(100.5, achievementRate)) / 100),
+        ratingAwardValue: Math.floor((coefficient * internalLevel * Math.min(100.5, achievementRate)) / 100) + apBonus,
         coefficient,
         rank: SCORE_COEFFICIENT_TABLE[i][2],
         index: i,


### PR DESCRIPTION
## Summary
- AP or AP+ combo flag now grants **+1** to the sheet's rating value, matching CiRCLE-era scoring rules
- `comboFlag` is threaded through `calculateRating`, `calculateB50`, and `useRatingEntries`
- `ComboFlag` type moved to `rating.ts` and re-exported from `RatingCalculatorAddEntryForm.tsx`
- 8 new unit tests covering AP/AP+ bonus, non-AP flags, edge cases, and B50 integration

## Test plan
- [x] All 56 rating unit tests pass (8 new AP bonus tests included)
- [ ] Verify AP/AP+ entries show +1 higher rating in the rating calculator UI
- [ ] Verify non-AP entries (FC, FC+, null) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)