### PR TITLE
fix: handle nullable LCH coordinates after colorjs.io v0.6 upgrade

### DIFF
--- a/apps/web/src/utils/color.ts
+++ b/apps/web/src/utils/color.ts
@@ -5,12 +5,12 @@ export const deriveColor = (color: string, type: 'border' | 'text' | 'overlay') 
   const c = new Color(color)
   return match(type)
     .with('border', () => {
-      c.lch.l -= 5
+      c.lch.l = (c.lch.l ?? 0) - 5
       return c.display()
     })
     .with('overlay', () => {
-      c.lch.l -= 20
-      c.lch.c += 10
+      c.lch.l = (c.lch.l ?? 0) - 20
+      c.lch.c = (c.lch.c ?? 0) + 10
       return c.display()
     })
     .with('text', () => {


### PR DESCRIPTION
## Summary
- **Fixes #200** — `colorjs.io` v0.6 changed LCH coordinate types from `number` to `number | null`, breaking arithmetic in `deriveColor()`
- Use nullish coalescing (`?? 0`) to safely default null lightness/chroma to 0 before arithmetic
- Defaulting to 0 is semantically correct per the CSS Color spec (null = achromatic/undefined)

## Test checklist
- [ ] Run `pnpm --filter @gekichumai/dxrating-web build` — should complete with no TypeScript errors
- [ ] Run `pnpm --filter @gekichumai/dxrating-web dev` and visually verify colored tag badges/overlays that use `deriveColor()` render correctly for border and overlay variants
- [ ] Confirm CI preview build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)