### PR TITLE
fix: INTL login endpoint trailing slash returns 404

### DIFF
--- a/apps/backend/src/lib/functions/URLS.ts
+++ b/apps/backend/src/lib/functions/URLS.ts
@@ -2,7 +2,7 @@ export const URLS = {
   INTL: {
     LOGIN_PAGE:
       'https://lng-tgk-aime-gw.am-all.net/common_auth/login?site_id=maimaidxex&redirect_url=https://maimaidx-eng.com/maimai-mobile/&back_url=https://maimai.sega.com/',
-    LOGIN_ENDPOINT: 'https://lng-tgk-aime-gw.am-all.net/common_auth/login/sid/',
+    LOGIN_ENDPOINT: 'https://lng-tgk-aime-gw.am-all.net/common_auth/login/sid',
     RECORD_RECENT_PAGE: 'https://maimaidx-eng.com/maimai-mobile/record',
     RECORD_MUSICS_PAGE: 'https://maimaidx-eng.com/maimai-mobile/record/musicGenre/search/',
   },

--- a/apps/backend/src/lib/functions/client.ts
+++ b/apps/backend/src/lib/functions/client.ts
@@ -264,19 +264,24 @@ export class MaimaiNETIntlClient extends Client {
 
     await this.fetch(URLS.INTL.LOGIN_PAGE)
 
-    const redirectURL = (
-      await this.fetch(URLS.INTL.LOGIN_ENDPOINT, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-        body: new URLSearchParams({
-          sid: id,
-          password,
-          retention: '1',
-        }),
-      })
-    ).headers.get('location')
+    const loginResponse = await this.fetch(URLS.INTL.LOGIN_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({
+        sid: id,
+        password,
+        retention: '1',
+      }),
+    })
+    if (loginResponse.status !== 302) {
+      throw new NetImportError(
+        'INTERNAL_ERROR',
+        `unexpected login response status: ${loginResponse.status} ${URLS.INTL.LOGIN_ENDPOINT}`,
+      )
+    }
+    const redirectURL = loginResponse.headers.get('location')
     if (!redirectURL) {
       throw new NetImportError('INVALID_CREDENTIALS')
     }


### PR DESCRIPTION
## Summary
- INTL MaimaiNET login POST hit `…/common_auth/login/sid/` (trailing `/`) — Sega gateway now returns **404**, no `Location` header, which surfaced in Sentry as a misleading `NetImportError: INVALID_CREDENTIALS` for every INTL import (issue 7359239905, span status_code 404).
- HAR capture of a working browser login confirms the gateway expects `…/common_auth/login/sid` (no trailing slash).
- Also added a status-code guard so future upstream changes throw `INTERNAL_ERROR` with the actual status + URL instead of masquerading as bad credentials.

## Test plan
- [ ] Trigger an INTL import with valid credentials and confirm 302 → `?ssid=` → home redirect chain completes.
- [ ] Trigger an INTL import with invalid credentials and confirm `INVALID_CREDENTIALS` still surfaces with the gateway error string.
- [ ] Verify Sentry no longer shows `NetImportError: INVALID_CREDENTIALS` at `client.ts:281` for affected users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)