### PR TITLE
Group GitHub Actions updates in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,12 @@
   "minimumReleaseAge": "5 days",
   "packageRules": [
     {
+      "description": "GitHub Actions",
+      "groupName": "github-actions",
+      "groupSlug": "github-actions",
+      "matchManagers": ["github-actions"]
+    },
+    {
       "description": "oRPC packages",
       "groupName": "orpc",
       "matchPackageNames": ["@orpc/**"]


### PR DESCRIPTION
## Summary
- Added a Renovate package rule for the `github-actions` manager.
- Groups all GitHub Actions dependency updates into a single `github-actions` PR.

## Testing
- Validated `renovate.json` as JSON.
- Ran Renovate config validation successfully.
- Checked formatting with `oxfmt`.