### PR TITLE
Fix Sentry tunnel and web config to accept the current DSN

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -126,8 +126,10 @@ const verifyParams = createMiddleware(async (c, next) => {
 })
 
 // Sentry tunnel — accepts raw envelope body, proxies as-is
-const SENTRY_HOST = 'o4506648698683392.ingest.us.sentry.io'
-const SENTRY_PROJECT_IDS = ['4511398317064192']
+const SENTRY_ALLOWED_DSN_TARGETS = new Set([
+  'o4506648698683392.ingest.sentry.io/4506648709627904',
+  'o4506648698683392.ingest.us.sentry.io/4511398317064192',
+])
 const MAX_TUNNEL_BODY_SIZE = 20 * 1024 * 1024 // 20 MB
 
 app.post('/api/v1/monitoring/tunnel', async (c) => {
@@ -145,12 +147,13 @@ app.post('/api/v1/monitoring/tunnel', async (c) => {
     const header = JSON.parse(envelope.split('\n')[0])
     const dsn = new URL(header.dsn)
     const projectId = dsn.pathname.replace('/', '')
+    const sentryTarget = `${dsn.hostname}/${projectId}`
 
-    if (dsn.hostname !== SENTRY_HOST || !SENTRY_PROJECT_IDS.includes(projectId)) {
+    if (!SENTRY_ALLOWED_DSN_TARGETS.has(sentryTarget)) {
       return c.json({ error: 'Invalid Sentry DSN' }, 400)
     }
 
-    await fetch(`https://${SENTRY_HOST}/api/${projectId}/envelope/`, {
+    await fetch(`https://${dsn.hostname}/api/${projectId}/envelope/`, {
       method: 'POST',
       body: envelope,
     })

--- a/apps/backend/src/test/sentry-tunnel.test.ts
+++ b/apps/backend/src/test/sentry-tunnel.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { app } from '../app.js'
+
+function envelopeFor(dsn: string) {
+  return `${JSON.stringify({ dsn })}\n${JSON.stringify({ type: 'event' })}\n{}`
+}
+
+async function postTunnelEnvelope(dsn: string) {
+  const envelope = envelopeFor(dsn)
+  const response = await app.request('/api/v1/monitoring/tunnel', {
+    method: 'POST',
+    body: envelope,
+  })
+
+  return { envelope, response }
+}
+
+describe('Sentry tunnel', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it.each([
+    [
+      'current US project',
+      'https://9346c04036724f129e00a750c8ab9415@o4506648698683392.ingest.us.sentry.io/4511398317064192',
+      'https://o4506648698683392.ingest.us.sentry.io/api/4511398317064192/envelope/',
+    ],
+    [
+      'legacy web project',
+      'https://1e929f3c3b929a213436e3c4dff57140@o4506648698683392.ingest.sentry.io/4506648709627904',
+      'https://o4506648698683392.ingest.sentry.io/api/4506648709627904/envelope/',
+    ],
+  ])('accepts the %s DSN', async (_name, dsn, expectedEnvelopeUrl) => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { envelope, response } = await postTunnelEnvelope(dsn)
+
+    expect(response.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledWith(expectedEnvelopeUrl, {
+      method: 'POST',
+      body: envelope,
+    })
+  })
+
+  it('rejects Sentry DSNs outside the allowlist', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { response } = await postTunnelEnvelope(
+      'https://9346c04036724f129e00a750c8ab9415@o4506648698683392.ingest.us.sentry.io/9999999999999999',
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'Invalid Sentry DSN' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- Update the backend Sentry tunnel allowlist to accept both the legacy project and the current US ingest DSN.
- Forward envelopes to the DSN’s actual regional host instead of hard-coding the old endpoint.
- Sync the web client and CSP security report endpoint to the current Sentry DSN.
- Add a regression test covering accepted and rejected tunnel DSNs.

## Testing
- Backend tunnel regression test added for valid legacy/current DSNs and invalid project IDs.
- Web security-header test continues to pass.
- `format:check`, backend build, web build, and lint were run successfully.