### PR TITLE
Harden passkey error handling to avoid React crashes on cancellation

### DIFF
--- a/apps/web/src/components/auth/LoginForm.tsx
+++ b/apps/web/src/components/auth/LoginForm.tsx
@@ -10,6 +10,7 @@ import IconLogosGithub from '~icons/logos/github-icon'
 import IconLogosGoogle from '~icons/logos/google-icon'
 import IconPasskey from '~icons/material-symbols/passkey'
 import { authClient } from '../../lib/auth-client'
+import { formatErrorMessage } from '../../utils/formatErrorMessage'
 
 const TURNSTILE_SITE_KEY = import.meta.env.VITE_TURNSTILE_SITE_KEY as string | undefined
 
@@ -112,9 +113,9 @@ export const LoginForm = ({
         toast.success(t('auth:login.toast-success'))
         onSuccess?.()
       }
-    } catch (e: any) {
+    } catch (e: unknown) {
       haptic.trigger('error')
-      setError(e.message || t('auth:form.error-generic'))
+      setError(formatErrorMessage(e, t('auth:form.error-generic')))
     } finally {
       setPendingProvider(null)
       turnstileRef.current?.reset()
@@ -134,15 +135,16 @@ export const LoginForm = ({
 
   const handlePasskey = async () => {
     setPendingProvider('passkey')
+    setError(null)
     try {
       const { error } = await authClient.signIn.passkey()
       if (error) throw error
       haptic.trigger('success')
       toast.success(t('auth:login.toast-success'))
       onSuccess?.()
-    } catch (e: any) {
+    } catch (e: unknown) {
       haptic.trigger('error')
-      setError(e.message || t('auth:form.error-passkey'))
+      setError(formatErrorMessage(e, t('auth:form.error-passkey')))
     } finally {
       setPendingProvider(null)
     }

--- a/apps/web/src/components/global/preferences/SecuritySection.tsx
+++ b/apps/web/src/components/global/preferences/SecuritySection.tsx
@@ -11,6 +11,7 @@ import IconMdiLock from '~icons/mdi/lock-outline'
 import IconPasskey from '~icons/material-symbols/passkey'
 import aaguidData from '../../../data/passkey-aaguids.json'
 import { authClient } from '../../../lib/auth-client'
+import { formatErrorMessage } from '../../../utils/formatErrorMessage'
 import { ConfirmDialog, useConfirmDialog } from '../ConfirmDialog'
 
 // -- Password Subsection --
@@ -124,9 +125,7 @@ const PasskeysSubsection: FC = () => {
   const [addState, handleAdd] = useAsyncFn(async () => {
     const res = await authClient.passkey.addPasskey()
     if (res.error) {
-      if (res.error.message) {
-        toast.error(t('auth:user-profile.passkeys.error', { error: res.error.message }))
-      }
+      toast.error(t('auth:user-profile.passkeys.error', { error: formatErrorMessage(res.error) }))
       return
     }
     toast.success(t('auth:user-profile.passkeys.added'))
@@ -140,8 +139,8 @@ const PasskeysSubsection: FC = () => {
       await authClient.passkey.deletePasskey({ id })
       toast.success(t('auth:user-profile.passkeys.deleted'))
       queryClient.invalidateQueries({ queryKey: ['passkeys'] })
-    } catch (e: any) {
-      toast.error(t('auth:user-profile.passkeys.error', { error: e.message }))
+    } catch (e: unknown) {
+      toast.error(t('auth:user-profile.passkeys.error', { error: formatErrorMessage(e) }))
     }
   }
 

--- a/apps/web/src/utils/__tests__/formatErrorMessage.test.ts
+++ b/apps/web/src/utils/__tests__/formatErrorMessage.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { formatErrorMessage } from '../formatErrorMessage'
+
+describe('formatErrorMessage', () => {
+  it('formats nested error-like message objects as text', () => {
+    const error = {
+      code: 'PASSKEY_AUTHENTICATION_FAILED',
+      message: {
+        code: 'NotAllowedError',
+        message: 'The operation either timed out or was not allowed.',
+        toString: () => 'NotAllowedError: The operation either timed out or was not allowed.',
+      },
+      toString: () => 'PASSKEY_AUTHENTICATION_FAILED',
+    }
+
+    expect(formatErrorMessage(error)).toBe('The operation either timed out or was not allowed.')
+  })
+})

--- a/apps/web/src/utils/formatErrorMessage.tsx
+++ b/apps/web/src/utils/formatErrorMessage.tsx
@@ -1,10 +1,42 @@
-export function formatErrorMessage(error: unknown) {
-  if (error instanceof Error) {
-    return error.message
+export function formatErrorMessage(error: unknown, fallback = 'An error occurred'): string {
+  return extractErrorMessage(error) ?? fallback
+}
+
+function extractErrorMessage(error: unknown): string | undefined {
+  if (typeof error === 'string') {
+    return error
   }
 
-  if (Object.prototype.hasOwnProperty.call(error, 'message')) {
-    return (error as { message: unknown }).message
+  if (typeof error === 'number' || typeof error === 'boolean' || typeof error === 'bigint') {
+    return String(error)
   }
-  return 'An error occurred'
+
+  if (!error) {
+    return undefined
+  }
+
+  if (error instanceof Error) {
+    return error.message || error.name
+  }
+
+  if (typeof error !== 'object') {
+    return undefined
+  }
+
+  const errorLike = error as { code?: unknown; message?: unknown; error?: unknown; toString?: unknown }
+  return (
+    extractErrorMessage(errorLike.message) ??
+    extractErrorMessage(errorLike.error) ??
+    extractErrorMessage(errorLike.code) ??
+    stringifyErrorLike(errorLike)
+  )
+}
+
+function stringifyErrorLike(error: { toString?: unknown }) {
+  if (typeof error.toString !== 'function' || error.toString === Object.prototype.toString) {
+    return undefined
+  }
+
+  const message = error.toString()
+  return typeof message === 'string' && message !== '[object Object]' ? message : undefined
 }


### PR DESCRIPTION
## Summary
- Normalize Better Auth and WebAuthn error values before rendering them in the auth UI.
- Route passkey sign-in and passkey management errors through a shared string formatter instead of reading `.message` directly.
- Add a regression test for nested error-like values such as the passkey cancellation case.

## Testing
- Added a focused unit test for `formatErrorMessage` covering nested passkey-style errors.
- Verified the web build, formatting, and linting locally; lint still reports existing unrelated warnings in the repo.