### PR TITLE
Move song detail routes under /songs/:songId/:type/:difficulty

### DIFF
--- a/apps/web/src/components/sheet/__tests__/sheetLinks.test.ts
+++ b/apps/web/src/components/sheet/__tests__/sheetLinks.test.ts
@@ -13,6 +13,6 @@ describe('buildSheetLink', () => {
         },
         'https://dxrating.net',
       ),
-    ).toBe('https://dxrating.net/song%20100%25/dx/master')
+    ).toBe('https://dxrating.net/songs/song%20100%25/dx/master')
   })
 })

--- a/apps/web/src/components/sheet/sheetLinks.ts
+++ b/apps/web/src/components/sheet/sheetLinks.ts
@@ -3,7 +3,7 @@ import type { FlattenedSheet } from '../../songs'
 type SheetLinkTarget = Pick<FlattenedSheet, 'songId' | 'type' | 'difficulty'>
 
 export const buildSheetPath = (sheet: SheetLinkTarget): string =>
-  `/${encodeURIComponent(sheet.songId)}/${encodeURIComponent(sheet.type)}/${encodeURIComponent(sheet.difficulty)}`
+  `/songs/${encodeURIComponent(sheet.songId)}/${encodeURIComponent(sheet.type)}/${encodeURIComponent(sheet.difficulty)}`
 
 export const buildSheetLink = (
   sheet: SheetLinkTarget,

--- a/apps/web/src/pages/SheetList.tsx
+++ b/apps/web/src/pages/SheetList.tsx
@@ -99,7 +99,7 @@ const _SheetListInner: FC = () => {
             difficulty: sheet.difficulty,
           }),
           mask: {
-            to: '/$songId/$type/$difficulty',
+            to: '/songs/$songId/$type/$difficulty',
             params: { songId: sheet.songId, type: sheet.type, difficulty: sheet.difficulty },
           },
           resetScroll: false,

--- a/apps/web/src/pages/SongPage.tsx
+++ b/apps/web/src/pages/SongPage.tsx
@@ -11,7 +11,7 @@ import { SongHeader } from '../components/song/SongHeader'
 import { SongSheetContent } from '../components/song/SongSheetContent'
 import { SongSheetTabs } from '../components/song/SongSheetTabs'
 
-const routeApi = getRouteApi('/$songId/$type/$difficulty')
+const routeApi = getRouteApi('/songs/$songId/$type/$difficulty')
 
 export const SongPage: FC = () => {
   const { t } = useTranslation(['song'])
@@ -54,7 +54,7 @@ export const SongPage: FC = () => {
   const handleTypeChange = (newType: TypeEnum) => {
     const sheetsOfType = flattenedSheets.filter((s) => s.type === newType)
     navigate({
-      to: '/$songId/$type/$difficulty',
+      to: '/songs/$songId/$type/$difficulty',
       params: {
         songId,
         type: newType,
@@ -65,7 +65,7 @@ export const SongPage: FC = () => {
 
   const handleDifficultyChange = (newDifficulty: DifficultyEnum) => {
     navigate({
-      to: '/$songId/$type/$difficulty',
+      to: '/songs/$songId/$type/$difficulty',
       params: {
         songId,
         type: activeType,

--- a/apps/web/src/routes/$songId/$type/$difficulty.tsx
+++ b/apps/web/src/routes/$songId/$type/$difficulty.tsx
@@ -1,11 +1,22 @@
 import { dxdata } from '@gekichumai/dxdata'
-import { createFileRoute, notFound } from '@tanstack/react-router'
-import { SongPage } from '@/pages/SongPage'
-import { buildSheetLink } from '@/components/sheet/sheetLinks'
+import { createFileRoute, notFound, redirect } from '@tanstack/react-router'
+
+export const LEGACY_SHEET_PATH_REDIRECT_STATUS_CODE = 308
+
+export const resolveLegacySheetPathRedirect = (songId: string, type: string, difficulty: string) => ({
+  to: '/songs/$songId/$type/$difficulty' as const,
+  params: {
+    songId,
+    type,
+    difficulty,
+  },
+  statusCode: LEGACY_SHEET_PATH_REDIRECT_STATUS_CODE,
+  replace: true,
+})
 
 export const Route = createFileRoute('/$songId/$type/$difficulty')({
   ssr: true,
-  loader: ({ params }) => {
+  beforeLoad: ({ params }) => {
     const song = dxdata.songs.find((s) => s.songId === params.songId)
     if (!song) {
       throw notFound()
@@ -16,67 +27,6 @@ export const Route = createFileRoute('/$songId/$type/$difficulty')({
       throw notFound()
     }
 
-    return { song, sheet }
+    throw redirect(resolveLegacySheetPathRedirect(params.songId, params.type, params.difficulty))
   },
-  head: ({ loaderData }) => {
-    const song = loaderData?.song
-    const sheet = loaderData?.sheet
-    if (!song || !sheet) {
-      return {
-        meta: [{ title: 'Song Not Found - DXRating' }],
-      }
-    }
-
-    const pageTitle = `${song.title} [${sheet.type} ${sheet.difficulty}] - DXRating`
-    const description = `${song.title} by ${song.artist} - ${sheet.type} ${sheet.difficulty} chart details, internal levels, and note counts on DXRating.`
-    const image = `https://shama.dxrating.net/images/cover/v2/${song.imageName}.jpg`
-    const url = buildSheetLink(
-      {
-        songId: song.songId,
-        type: sheet.type,
-        difficulty: sheet.difficulty,
-      },
-      'https://dxrating.net',
-    )
-
-    return {
-      meta: [
-        { title: pageTitle },
-        { name: 'description', content: description },
-        { property: 'og:title', content: pageTitle },
-        { property: 'og:description', content: description },
-        { property: 'og:image', content: image },
-        { property: 'og:url', content: url },
-        { property: 'og:type', content: 'website' },
-        { name: 'twitter:card', content: 'summary_large_image' },
-        { name: 'twitter:title', content: pageTitle },
-        { name: 'twitter:description', content: description },
-        { name: 'twitter:image', content: image },
-      ],
-      links: [{ rel: 'canonical', href: url }],
-      scripts: [
-        {
-          type: 'application/ld+json',
-          children: JSON.stringify({
-            '@context': 'https://schema.org',
-            '@type': 'MusicComposition',
-            name: song.title,
-            composer: {
-              '@type': 'Person',
-              name: song.artist,
-            },
-            image,
-            url,
-            genre: song.category,
-            isPartOf: {
-              '@type': 'WebSite',
-              name: 'DXRating',
-              url: 'https://dxrating.net',
-            },
-          }),
-        },
-      ],
-    }
-  },
-  component: SongPage,
 })

--- a/apps/web/src/routes/__tests__/-legacy-song-redirect.test.ts
+++ b/apps/web/src/routes/__tests__/-legacy-song-redirect.test.ts
@@ -1,6 +1,7 @@
 import { CategoryEnum, DifficultyEnum, TypeEnum, type Song } from '@gekichumai/dxdata'
 import { describe, expect, it } from 'vitest'
-import { LEGACY_SONG_ROUTE_REDIRECT_STATUS_CODE, resolveLegacySongRouteRedirect } from '../songs/$songId'
+import { LEGACY_SHEET_PATH_REDIRECT_STATUS_CODE, resolveLegacySheetPathRedirect } from '../$songId/$type/$difficulty'
+import { LEGACY_SONG_ROUTE_REDIRECT_STATUS_CODE, resolveLegacySongRouteRedirect } from '../songs_.$songId'
 
 const song = {
   songId: 'song-1',
@@ -41,7 +42,7 @@ const song = {
 describe('resolveLegacySongRouteRedirect', () => {
   it('permanently redirects old query URLs to the matching path route', () => {
     expect(resolveLegacySongRouteRedirect(song, TypeEnum.STD, DifficultyEnum.Master)).toEqual({
-      to: '/$songId/$type/$difficulty',
+      to: '/songs/$songId/$type/$difficulty',
       params: {
         songId: 'song-1',
         type: TypeEnum.STD,
@@ -62,5 +63,21 @@ describe('resolveLegacySongRouteRedirect', () => {
       },
       statusCode: 308,
     })
+  })
+})
+
+describe('resolveLegacySheetPathRedirect', () => {
+  it('permanently redirects old root-level sheet URLs to the songs route', () => {
+    expect(resolveLegacySheetPathRedirect('song-1', TypeEnum.STD, DifficultyEnum.Master)).toEqual({
+      to: '/songs/$songId/$type/$difficulty',
+      params: {
+        songId: 'song-1',
+        type: TypeEnum.STD,
+        difficulty: DifficultyEnum.Master,
+      },
+      statusCode: LEGACY_SHEET_PATH_REDIRECT_STATUS_CODE,
+      replace: true,
+    })
+    expect(LEGACY_SHEET_PATH_REDIRECT_STATUS_CODE).toBe(308)
   })
 })

--- a/apps/web/src/routes/__tests__/-sitemap.test.ts
+++ b/apps/web/src/routes/__tests__/-sitemap.test.ts
@@ -12,7 +12,7 @@ describe('buildSitemap', () => {
     ])
 
     expect(sitemap).toContain(
-      '<loc>https://dxrating.net/1%2F3%E3%81%AE%E7%B4%94%E6%83%85%E3%81%AA%E6%84%9F%E6%83%85%20%26%20%3Ctest%3E/dx/master</loc>',
+      '<loc>https://dxrating.net/songs/1%2F3%E3%81%AE%E7%B4%94%E6%83%85%E3%81%AA%E6%84%9F%E6%83%85%20%26%20%3Ctest%3E/dx/master</loc>',
     )
     expect(sitemap).not.toContain('<loc>https://dxrating.net/1/3の純情な感情 & <test>/dx/master</loc>')
   })
@@ -36,7 +36,7 @@ describe('buildSitemap', () => {
       },
     ])
 
-    expect(sitemap.indexOf('/mixed/std/master')).toBeLessThan(sitemap.indexOf('/recent/dx/expert'))
-    expect(sitemap.indexOf('/recent/dx/expert')).toBeLessThan(sitemap.indexOf('/old/dx/master'))
+    expect(sitemap.indexOf('/songs/mixed/std/master')).toBeLessThan(sitemap.indexOf('/songs/recent/dx/expert'))
+    expect(sitemap.indexOf('/songs/recent/dx/expert')).toBeLessThan(sitemap.indexOf('/songs/old/dx/master'))
   })
 })

--- a/apps/web/src/routes/songs/$songId/$type/$difficulty.tsx
+++ b/apps/web/src/routes/songs/$songId/$type/$difficulty.tsx
@@ -1,0 +1,82 @@
+import { dxdata } from '@gekichumai/dxdata'
+import { createFileRoute, notFound } from '@tanstack/react-router'
+import { buildSheetLink } from '@/components/sheet/sheetLinks'
+import { SongPage } from '@/pages/SongPage'
+
+export const Route = createFileRoute('/songs/$songId/$type/$difficulty')({
+  ssr: true,
+  loader: ({ params }) => {
+    const song = dxdata.songs.find((s) => s.songId === params.songId)
+    if (!song) {
+      throw notFound()
+    }
+
+    const sheet = song.sheets.find((s) => s.type === params.type && s.difficulty === params.difficulty)
+    if (!sheet) {
+      throw notFound()
+    }
+
+    return { song, sheet }
+  },
+  head: ({ loaderData }) => {
+    const song = loaderData?.song
+    const sheet = loaderData?.sheet
+    if (!song || !sheet) {
+      return {
+        meta: [{ title: 'Song Not Found - DXRating' }],
+      }
+    }
+
+    const pageTitle = `${song.title} [${sheet.type} ${sheet.difficulty}] - DXRating`
+    const description = `${song.title} by ${song.artist} - ${sheet.type} ${sheet.difficulty} chart details, internal levels, and note counts on DXRating.`
+    const image = `https://shama.dxrating.net/images/cover/v2/${song.imageName}.jpg`
+    const url = buildSheetLink(
+      {
+        songId: song.songId,
+        type: sheet.type,
+        difficulty: sheet.difficulty,
+      },
+      'https://dxrating.net',
+    )
+
+    return {
+      meta: [
+        { title: pageTitle },
+        { name: 'description', content: description },
+        { property: 'og:title', content: pageTitle },
+        { property: 'og:description', content: description },
+        { property: 'og:image', content: image },
+        { property: 'og:url', content: url },
+        { property: 'og:type', content: 'website' },
+        { name: 'twitter:card', content: 'summary_large_image' },
+        { name: 'twitter:title', content: pageTitle },
+        { name: 'twitter:description', content: description },
+        { name: 'twitter:image', content: image },
+      ],
+      links: [{ rel: 'canonical', href: url }],
+      scripts: [
+        {
+          type: 'application/ld+json',
+          children: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'MusicComposition',
+            name: song.title,
+            composer: {
+              '@type': 'Person',
+              name: song.artist,
+            },
+            image,
+            url,
+            genre: song.category,
+            isPartOf: {
+              '@type': 'WebSite',
+              name: 'DXRating',
+              url: 'https://dxrating.net',
+            },
+          }),
+        },
+      ],
+    }
+  },
+  component: SongPage,
+})

--- a/apps/web/src/routes/songs_.$songId.tsx
+++ b/apps/web/src/routes/songs_.$songId.tsx
@@ -41,7 +41,7 @@ const getLegacySheetParams = (song: Song, requestedType?: string, requestedDiffi
 export const resolveLegacySongRouteRedirect = (song: Song, requestedType?: string, requestedDifficulty?: string) => {
   const { type, difficulty } = getLegacySheetParams(song, requestedType, requestedDifficulty)
   return {
-    to: '/$songId/$type/$difficulty' as const,
+    to: '/songs/$songId/$type/$difficulty' as const,
     params: {
       songId: song.songId,
       type,
@@ -52,7 +52,7 @@ export const resolveLegacySongRouteRedirect = (song: Song, requestedType?: strin
   }
 }
 
-export const Route = createFileRoute('/songs/$songId')({
+export const Route = createFileRoute('/songs_/$songId')({
   ssr: true,
   validateSearch: (search: Record<string, unknown>): SongSearchParams => ({
     type: typeof search.type === 'string' ? search.type : undefined,


### PR DESCRIPTION
## Summary
- Update canonical song sheet URLs to use `/songs/:songId/:type/:difficulty`
- Add the canonical nested route and keep old root/query song URLs as 308 redirects
- Update song page navigation, masked search navigation, sitemap generation, and sheet link helpers to match the new path
- Refresh route/link tests to cover the new URL shape and redirect behavior

## Testing
- `pnpm format:check`
- `pnpm lint`
- `pnpm --filter @gekichumai/dxrating-web build`
- `pnpm test -- run src/components/sheet/__tests__/sheetLinks.test.ts src/routes/__tests__/-legacy-song-redirect.test.ts src/routes/__tests__/-sitemap.test.ts`
- Verified locally that canonical and legacy song URLs resolve to the expected final route