### PR TITLE
Skip difficulty filtering for Utage charts

### DIFF
--- a/apps/web/src/pages/SheetList.tsx
+++ b/apps/web/src/pages/SheetList.tsx
@@ -14,6 +14,7 @@ import { SheetSortFilter, type SheetSortFilterForm } from '../components/sheet/S
 import { SheetDetailsContext, SheetDetailsContextProvider } from '../models/context/SheetDetailsContext'
 import { useAppContextDXDataVersion } from '../models/context/useAppContext'
 import { type FlattenedSheet, canonicalIdFromParts, useFilteredSheets, useSheets } from '../songs'
+import { sheetMatchesDifficultyFilter } from './sheetDifficultyFilter'
 
 const searchRouteApi = getRouteApi('/search')
 
@@ -162,13 +163,7 @@ const _SheetListInner: FC = () => {
             return true
           },
 
-          (v) => {
-            if (sortFilterOptions.filters.difficulties) {
-              const difficulties = sortFilterOptions.filters.difficulties
-              return difficulties.some((difficulty) => v.difficulty === difficulty)
-            }
-            return true
-          },
+          (v) => sheetMatchesDifficultyFilter(v, sortFilterOptions.filters.difficulties),
 
           (v) => {
             if (favoriteSheetIds) {

--- a/apps/web/src/pages/__tests__/sheetDifficultyFilter.test.ts
+++ b/apps/web/src/pages/__tests__/sheetDifficultyFilter.test.ts
@@ -1,0 +1,23 @@
+import { DifficultyEnum, TypeEnum } from '@gekichumai/dxdata'
+import { describe, expect, it } from 'vitest'
+import { sheetMatchesDifficultyFilter } from '../sheetDifficultyFilter'
+
+describe('sheetMatchesDifficultyFilter', () => {
+  const selectedDifficulties = [DifficultyEnum.Master]
+
+  it('filters normal charts by selected difficulty', () => {
+    expect(
+      sheetMatchesDifficultyFilter({ type: TypeEnum.DX, difficulty: DifficultyEnum.Basic }, selectedDifficulties),
+    ).toBe(false)
+
+    expect(
+      sheetMatchesDifficultyFilter({ type: TypeEnum.STD, difficulty: DifficultyEnum.Master }, selectedDifficulties),
+    ).toBe(true)
+  })
+
+  it.each([TypeEnum.UTAGE, TypeEnum.UTAGE2P])('does not filter %s charts by difficulty', (type) => {
+    expect(sheetMatchesDifficultyFilter({ type, difficulty: '【宴】' as DifficultyEnum }, selectedDifficulties)).toBe(
+      true,
+    )
+  })
+})

--- a/apps/web/src/pages/sheetDifficultyFilter.ts
+++ b/apps/web/src/pages/sheetDifficultyFilter.ts
@@ -1,0 +1,16 @@
+import { type DifficultyEnum, TypeEnum } from '@gekichumai/dxdata'
+
+export const sheetMatchesDifficultyFilter = (
+  sheet: { type: TypeEnum; difficulty: DifficultyEnum | string },
+  difficulties: readonly DifficultyEnum[] | undefined,
+) => {
+  if (sheet.type === TypeEnum.UTAGE || sheet.type === TypeEnum.UTAGE2P) {
+    return true
+  }
+
+  if (!difficulties) {
+    return true
+  }
+
+  return difficulties.includes(sheet.difficulty as DifficultyEnum)
+}


### PR DESCRIPTION
## Summary
- Keep `utage` and `utage2p` sheets visible regardless of the selected difficulty filter
- Extract the difficulty match logic into a small helper used by the sheet list
- Add regression coverage for normal charts and both Utage chart types

## Testing
- Added unit tests for the difficulty filter helper
- `pnpm format:check` passed
- `pnpm lint` passed with existing repo warnings only
- `pnpm --filter @gekichumai/dxrating-web build` passed