### PR TITLE
Show server aliases on song detail pages

### DIFF
--- a/apps/web/src/components/sheet/SheetAltNames.tsx
+++ b/apps/web/src/components/sheet/SheetAltNames.tsx
@@ -1,0 +1,53 @@
+import clsx from 'clsx'
+import { type FC, useState } from 'react'
+import toast from 'react-hot-toast'
+import { useTranslation } from 'react-i18next'
+
+export const SheetAltNames: FC<{ altNames: string[] }> = ({ altNames }) => {
+  const { t } = useTranslation(['sheet'])
+  const [expanded, setExpanded] = useState(false)
+
+  return (
+    <div
+      className={clsx('text-sm text-slate-600 overflow-hidden', !expanded && 'max-h-[7rem]')}
+      style={{
+        mask: expanded
+          ? undefined
+          : 'linear-gradient(to bottom, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 5rem, rgba(0,0,0,0) 100%)',
+        WebkitMask: expanded
+          ? undefined
+          : 'linear-gradient(to bottom, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 5rem, rgba(0,0,0,0) 100%)',
+      }}
+    >
+      {altNames?.map((altName, i) => (
+        <span className="inline-block whitespace-pre-line" key={altName}>
+          <button
+            type="button"
+            className="cursor-pointer border-0 bg-transparent p-0 text-inherit font-inherit text-left"
+            onClick={() => {
+              setExpanded(true)
+              if (altName.length > 50) {
+                const sanitizedAltName = altName.trim()
+                navigator.clipboard.writeText(`${sanitizedAltName}是什么歌`)
+                toast.success(t('sheet:copy-alt-name.toast-success', { content: `${sanitizedAltName}是什么歌` }), {
+                  id: `copy-sheet-alt-name-${altName}`,
+                })
+              } else {
+                const sanitizedAltName = altName
+                  .trim()
+                  .replace(/[\s|\n|，|。|！|@|；|《|》|？|：|【|】|（|）|、|·|~|!|#|%|&|*|(|)|{|}|\\[|\\]|\\|]/g, '-')
+                navigator.clipboard.writeText(`https://${sanitizedAltName}.是什么歌.com`)
+                toast.success(t('sheet:copy-alt-name.toast-success', { content: `${sanitizedAltName}.是什么歌.com` }), {
+                  id: `copy-sheet-alt-name-${altName}`,
+                })
+              }
+            }}
+          >
+            {altName}
+          </button>
+          {i < altNames.length - 1 && <span className="text-slate-400 mx-1 select-none">/</span>}
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/apps/web/src/components/sheet/SheetListItem.tsx
+++ b/apps/web/src/components/sheet/SheetListItem.tsx
@@ -16,6 +16,7 @@ import { useIsLargeDevice } from '../../utils/breakpoints'
 import { FadedImage } from '../global/FadedImage'
 import { ResponsiveDialog } from '../global/ResponsiveDialog'
 import { AddSheetAltNameButton } from './AddSheetAltNameButton'
+import { SheetAltNames } from './SheetAltNames'
 import { SheetDialogContent, type SheetDialogContentProps } from './SheetDialogContent'
 import { buildSheetPath } from './sheetLinks'
 
@@ -296,54 +297,6 @@ export const SheetTitle: FC<SheetTitleProps> = ({
           <span className="text-zinc-600">ver. {version}</span>
         </div>
       )}
-    </div>
-  )
-}
-
-export const SheetAltNames: FC<{ altNames: string[] }> = ({ altNames }) => {
-  const { t } = useTranslation(['sheet'])
-  const [expanded, setExpanded] = useState(false)
-
-  return (
-    <div
-      className={clsx('text-sm text-slate-600 overflow-hidden', !expanded && 'max-h-[7rem]')}
-      style={{
-        mask: expanded
-          ? undefined
-          : 'linear-gradient(to bottom, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 5rem, rgba(0,0,0,0) 100%)',
-        WebkitMask: expanded
-          ? undefined
-          : 'linear-gradient(to bottom, rgba(0,0,0,1) 0%, rgba(0,0,0,1) 5rem, rgba(0,0,0,0) 100%)',
-      }}
-      onClick={() => setExpanded(true)}
-    >
-      {altNames?.map((altName, i) => (
-        <span className="inline-block whitespace-pre-line" key={altName}>
-          <span
-            className="cursor-pointer"
-            onClick={() => {
-              if (altName.length > 50) {
-                const sanitizedAltName = altName.trim()
-                navigator.clipboard.writeText(`${sanitizedAltName}是什么歌`)
-                toast.success(t('sheet:copy-alt-name.toast-success', { content: `${sanitizedAltName}是什么歌` }), {
-                  id: `copy-sheet-alt-name-${altName}`,
-                })
-              } else {
-                const sanitizedAltName = altName
-                  .trim()
-                  .replace(/[\s|\n|，|。|！|@|；|《|》|？|：|【|】|（|）|、|·|~|!|#|%|&|*|(|)|{|}|\\[|\\]|\\|]/g, '-')
-                navigator.clipboard.writeText(`https://${sanitizedAltName}.是什么歌.com`)
-                toast.success(t('sheet:copy-alt-name.toast-success', { content: `${sanitizedAltName}.是什么歌.com` }), {
-                  id: `copy-sheet-alt-name-${altName}`,
-                })
-              }
-            }}
-          >
-            {altName}
-          </span>
-          {i < altNames.length - 1 && <span className="text-slate-400 mx-1 select-none">/</span>}
-        </span>
-      ))}
     </div>
   )
 }

--- a/apps/web/src/components/song/SongHeader.tsx
+++ b/apps/web/src/components/song/SongHeader.tsx
@@ -1,4 +1,3 @@
-import type { Song } from '@gekichumai/dxdata'
 import { Button, ButtonGroup, IconButton } from '@mui/material'
 import { motion } from 'framer-motion'
 import { type FC, useState } from 'react'
@@ -9,11 +8,15 @@ import IconMdiSpotify from '~icons/mdi/spotify'
 import IconMdiYouTube from '~icons/mdi/youtube'
 import RiBilibiliFill from '~icons/ri/bilibili-fill'
 import MdiImageRemove from '~icons/mdi/image-remove'
+import type { FlattenedSheet } from '../../songs'
+import { AddSheetAltNameButton } from '../sheet/AddSheetAltNameButton'
+import { SheetAltNames } from '../sheet/SheetAltNames'
 
-export const SongHeader: FC<{ song: Song }> = ({ song }) => {
+export const SongHeader: FC<{ sheet: FlattenedSheet }> = ({ sheet }) => {
   const { t } = useTranslation(['sheet'])
   const [imgExpanded, setImgExpanded] = useState(false)
   const [imgError, setImgError] = useState(false)
+  const song = sheet
 
   const coverUrl = `https://shama.dxrating.net/images/cover/v2/${song.imageName}.jpg`
 
@@ -67,6 +70,10 @@ export const SongHeader: FC<{ song: Song }> = ({ song }) => {
           </h1>
           <div className="text-sm text-zinc-600">{song.artist}</div>
           <div className="text-sm text-zinc-500">{song.category}</div>
+          <div className="w-full font-bold flex flex-col pt-1">
+            {song.searchAcronyms.length > 0 && <SheetAltNames altNames={song.searchAcronyms} />}
+            <AddSheetAltNameButton sheet={sheet} />
+          </div>
         </div>
       </div>
 

--- a/apps/web/src/pages/SongPage.tsx
+++ b/apps/web/src/pages/SongPage.tsx
@@ -6,7 +6,8 @@ import { getRouteApi, useNavigate } from '@tanstack/react-router'
 import MdiArrowLeft from '~icons/mdi/arrow-left'
 import { TYPE_ORDER, getHighestDifficulty } from '../models/constants'
 import { useAppContextDXDataVersion } from '../models/context/useAppContext'
-import { type FlattenedSheet, canonicalId } from '../songs'
+import { useServerAliases } from '../models/useServerAliases'
+import { type FlattenedSheet, canonicalId, getSearchAcronymsWithServerAliases } from '../songs'
 import { SongHeader } from '../components/song/SongHeader'
 import { SongSheetContent } from '../components/song/SongSheetContent'
 import { SongSheetTabs } from '../components/song/SongSheetTabs'
@@ -18,11 +19,17 @@ export const SongPage: FC = () => {
   const { songId, type, difficulty } = routeApi.useParams()
   const navigate = useNavigate()
   const appVersion = useAppContextDXDataVersion()
+  const { data: serverAliases } = useServerAliases()
 
   const song = useMemo(() => {
     if (!songId) return null
     return dxdata.songs.find((s) => s.songId === songId) ?? null
   }, [songId])
+
+  const searchAcronyms = useMemo(() => {
+    if (!song) return []
+    return getSearchAcronymsWithServerAliases(song, serverAliases)
+  }, [song, serverAliases])
 
   const flattenedSheets = useMemo<FlattenedSheet[]>(() => {
     if (!song) return []
@@ -32,16 +39,17 @@ export const SongPage: FC = () => {
         ...song,
         ...sheet,
         id: canonicalId(song, sheet),
-        searchAcronyms: song.searchAcronyms,
+        searchAcronyms,
         isTypeUtage,
         isRatingEligible: !isTypeUtage,
+        tags: [],
         releaseDateTimestamp: sheet.releaseDate ? new Date(`${sheet.releaseDate}T06:00:00+09:00`).valueOf() : 0,
         internalLevelValue: sheet.multiverInternalLevelValue
           ? (sheet.multiverInternalLevelValue[appVersion] ?? sheet.internalLevelValue)
           : sheet.internalLevelValue,
       } as FlattenedSheet
     })
-  }, [song, appVersion])
+  }, [song, searchAcronyms, appVersion])
 
   const availableTypes = useMemo(() => {
     const typeSet = new Set(flattenedSheets.map((s) => s.type))
@@ -50,6 +58,10 @@ export const SongPage: FC = () => {
 
   const activeType = type as TypeEnum
   const activeDifficulty = difficulty as DifficultyEnum
+  const activeSheet = flattenedSheets.find(
+    (sheet) => sheet.type === activeType && sheet.difficulty === activeDifficulty,
+  )
+  const headerSheet = activeSheet ?? flattenedSheets[0]
 
   const handleTypeChange = (newType: TypeEnum) => {
     const sheetsOfType = flattenedSheets.filter((s) => s.type === newType)
@@ -103,7 +115,7 @@ export const SongPage: FC = () => {
         </IconButton>
       </a>
 
-      <SongHeader song={song} />
+      {headerSheet && <SongHeader sheet={headerSheet} />}
 
       <SongSheetTabs
         sheets={song.sheets}

--- a/apps/web/src/songs.test.ts
+++ b/apps/web/src/songs.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { getSearchAcronymsWithServerAliases } from './songs'
+
+describe('getSearchAcronymsWithServerAliases', () => {
+  it('merges generated aliases with server aliases for the current song', () => {
+    expect(
+      getSearchAcronymsWithServerAliases(
+        {
+          songId: 'song-1',
+          searchAcronyms: ['generated alias', 'shared alias'],
+        },
+        [
+          { song_id: 'song-1', name: 'server alias' },
+          { song_id: 'song-1', name: 'shared alias' },
+          { song_id: 'song-2', name: 'other song alias' },
+        ],
+      ),
+    ).toEqual(['generated alias', 'shared alias', 'server alias'])
+  })
+})

--- a/apps/web/src/songs.ts
+++ b/apps/web/src/songs.ts
@@ -31,6 +31,21 @@ export const getSongs = (): Song[] => {
   return dxdata.songs
 }
 
+export interface ServerAlias {
+  song_id: string
+  name: string
+}
+
+export const getSearchAcronymsWithServerAliases = (
+  song: Pick<Song, 'songId' | 'searchAcronyms'>,
+  serverAliases?: readonly ServerAlias[] | null,
+) => {
+  return uniq([
+    ...song.searchAcronyms,
+    ...(serverAliases?.filter((alias) => alias.song_id === song.songId).map((alias) => alias.name) ?? []),
+  ])
+}
+
 export const getFlattenedSheets = async (version: VersionEnum): Promise<FlattenedSheet[]> => {
   const songs = getSongs()
   const flattenedSheets = songs.flatMap((song) => {
@@ -128,10 +143,13 @@ export const useSheetsSearchEngine = () => {
     return new Fuse(
       songs?.map((song) => ({
         ...song,
-        searchAcronyms: [
-          ...song.searchAcronyms.filter((acronym) => acronym.length < 70),
-          ...(serverAliases?.filter((alias) => alias.song_id === song.songId).map((alias) => alias.name) ?? []),
-        ],
+        searchAcronyms: getSearchAcronymsWithServerAliases(
+          {
+            songId: song.songId,
+            searchAcronyms: song.searchAcronyms.filter((acronym) => acronym.length < 70),
+          },
+          serverAliases,
+        ),
       })) ?? [],
       {
         keys: [


### PR DESCRIPTION
## Summary
- Song detail pages now merge server aliases with generated `searchAcronyms` so aliases appear on the song header.
- Reused the existing alias display component on the detail page and kept the add-alias action there as well.
- Extracted alias merging into a shared helper so search and detail views use the same logic.
- Added a focused unit test for the alias merge behavior.

## Testing
- `pnpm vitest run src/songs.test.ts`
- `pnpm format:check`
- `pnpm lint` (passed with pre-existing warnings)
- `pnpm --filter @gekichumai/dxrating-web build`
- Local browser check on a song detail page confirmed aliases render in the header.