### PR TITLE
fix: tag filter should have gesture hint

### DIFF
--- a/apps/web/src/components/sheet/filters/SheetTagFilter.tsx
+++ b/apps/web/src/components/sheet/filters/SheetTagFilter.tsx
@@ -12,6 +12,7 @@ import { zoomTransitions } from '../../../utils/motionConstants'
 import { useLocalizedMessageTranslation } from '../../../utils/useLocalizedMessageTranslation'
 import type { SheetSortFilterForm } from '../SheetSortFilter'
 import { SheetFilterSection } from './SheetFilterSection'
+import { GestureHint } from '@/components/global/GestureHint'
 
 const SheetTagFilterInputTag = ({
   label,
@@ -175,7 +176,16 @@ export const SheetTagFilter: FC<{
   })
 
   return (
-    <SheetFilterSection titleLeft={t('sheet:filter.tags.title')} reset={reset}>
+    <SheetFilterSection
+      titleLeft={t('sheet:filter.tags.title')}
+      titleRight={
+        <>
+          <GestureHint gesture="tap" description={t('sheet:filter.difficulty.gesture-hint.tap')} />
+          <GestureHint gesture="tap-hold" description={t('sheet:filter.difficulty.gesture-hint.tap-hold')} />
+        </>
+      }
+      reset={reset}
+    >
       <SheetTagFilterInput value={value} onChange={onChange} />
     </SheetFilterSection>
   )


### PR DESCRIPTION
Added gesture hint.
<img width="608" height="161" alt="image" src="https://github.com/user-attachments/assets/87bdc52f-39af-42e0-be65-46e747c88688" />
