### PR TITLE
fix: add corresponding lang attribute to each locale selector item

### DIFF
--- a/apps/web/src/components/global/preferences/LocaleSelector.tsx
+++ b/apps/web/src/components/global/preferences/LocaleSelector.tsx
@@ -17,6 +17,7 @@ const LocaleSelectorItem: FC<PropsWithChildren<{ locale: SupportedLocale; select
 
   return (
     <MenuItem
+      lang={locale}
       selected={selected}
       onClick={() => {
         startViewTransition(() => {


### PR DESCRIPTION
Added HTML `lang` attribute to each locale selector item to avoid flickering due to CJK font preference when switching between locales.