### PR TITLE
Add localized SEO metadata and locale-aware route rendering

### DIFF
--- a/apps/web/src/components/sheet/__tests__/sheetLinks.test.ts
+++ b/apps/web/src/components/sheet/__tests__/sheetLinks.test.ts
@@ -15,4 +15,17 @@ describe('buildSheetLink', () => {
       ),
     ).toBe('https://dxrating.net/songs/song%20100%25/dx/master')
   })
+
+  it('builds links for UTAGE custom difficulty labels', () => {
+    expect(
+      buildSheetLink(
+        {
+          songId: 'utage-song',
+          type: TypeEnum.UTAGE,
+          difficulty: '【協】',
+        },
+        'https://dxrating.net',
+      ),
+    ).toBe('https://dxrating.net/songs/utage-song/utage/%E3%80%90%E5%8D%94%E3%80%91')
+  })
 })

--- a/apps/web/src/components/sheet/sheetLinks.ts
+++ b/apps/web/src/components/sheet/sheetLinks.ts
@@ -1,6 +1,10 @@
-import type { FlattenedSheet } from '../../songs'
+import type { DifficultyEnum, TypeEnum } from '@gekichumai/dxdata'
 
-type SheetLinkTarget = Pick<FlattenedSheet, 'songId' | 'type' | 'difficulty'>
+type SheetLinkTarget = {
+  songId: string
+  type: TypeEnum
+  difficulty: DifficultyEnum | string
+}
 
 export const buildSheetPath = (sheet: SheetLinkTarget): string =>
   `/songs/${encodeURIComponent(sheet.songId)}/${encodeURIComponent(sheet.type)}/${encodeURIComponent(sheet.difficulty)}`

--- a/apps/web/src/locales/resources/en.json
+++ b/apps/web/src/locales/resources/en.json
@@ -2,11 +2,19 @@
   "root": {
     "pages": {
       "search": {
-        "title": "Search Charts"
+        "title": "Search Charts",
+        "seo-title": "Charts & Songs",
+        "seo-description": "Browse all maimai DX charts by song title, artist, or difficulty. View internal levels, note counts, and detailed chart information."
       },
       "rating": {
-        "title": "My Rating"
+        "title": "My Rating",
+        "seo-title": "Rating Calculator",
+        "seo-description": "Calculate and manage your maimai DX rating records, Best 50 entries, achievements, and score details on DXRating."
       }
+    },
+    "seo": {
+      "description": "DXRating is a maimai DX Rating analyzer, along with other features like chart details and more.",
+      "keywords": "maimai, maimai DX, maimai DX Rating, maimai DX Rating analyzer, gekichumai, maimai derakkusu, chart details, rating calculator, maimai wiki"
     },
     "share": {
       "copy-succeeded": "Copied to clipboard",
@@ -174,6 +182,9 @@
       "dx": "DX",
       "std": "Standard",
       "utage": "Utage"
+    },
+    "seo": {
+      "description": "{{title}} by {{artist}} - {{sheetLabel}} chart details, internal levels, and note counts on DXRating."
     }
   },
   "about": {

--- a/apps/web/src/locales/resources/ja.json
+++ b/apps/web/src/locales/resources/ja.json
@@ -2,11 +2,19 @@
   "root": {
     "pages": {
       "search": {
-        "title": "譜面検索"
+        "title": "譜面検索",
+        "seo-title": "譜面検索",
+        "seo-description": "maimai DX の譜面を、楽曲名、アーティスト、難易度から検索できます。譜面定数、ノーツ数、詳しい譜面情報も確認できます。"
       },
       "rating": {
-        "title": "レーテイング計算"
+        "title": "レーテイング計算",
+        "seo-title": "レーティング計算",
+        "seo-description": "maimai DX のレーティング記録、Best 50、達成率、スコア詳細を DXRating で計算・管理できます。"
       }
+    },
+    "seo": {
+      "description": "DXRating は maimai DX Rating の分析ツールです。譜面詳細などの機能も提供しています。",
+      "keywords": "maimai, maimai DX, maimai DX Rating, maimai DX Rating 分析, ゲキチュウマイ, maimaiでらっくす, 譜面情報, レーティング計算, maimai wiki"
     },
     "share": {
       "copy-content": "{{ link }}",
@@ -174,6 +182,9 @@
       "dx": "でらっくす",
       "std": "スタンダード",
       "utage": "宴"
+    },
+    "seo": {
+      "description": "{{title}} / {{artist}} - {{sheetLabel}} の譜面詳細、譜面定数、ノーツ数 - DXRating。"
     }
   },
   "about": {

--- a/apps/web/src/locales/resources/zh-Hans.json
+++ b/apps/web/src/locales/resources/zh-Hans.json
@@ -2,11 +2,19 @@
   "root": {
     "pages": {
       "search": {
-        "title": "搜索谱面"
+        "title": "搜索谱面",
+        "seo-title": "搜索谱面",
+        "seo-description": "按歌曲名、艺术家或难度浏览所有 maimai DX 谱面，查看谱面定数、音符数和详细谱面信息。"
       },
       "rating": {
-        "title": "计算评分"
+        "title": "计算评分",
+        "seo-title": "评分计算器",
+        "seo-description": "在 DXRating 计算和管理你的 maimai DX Rating 记录、Best 50、达成率和分数详情。"
       }
+    },
+    "seo": {
+      "description": "DXRating 是 maimai DX Rating 分析工具，也提供谱面详情等功能。",
+      "keywords": "maimai, maimai DX, maimai DX Rating, maimai DX Rating 分析工具, 中二节奏, 舞萌, 舞萌DX, 谱面详情, 评分计算器, maimai wiki"
     },
     "share": {
       "copy-content": "{{ link }}",
@@ -173,6 +181,9 @@
       "dx": "DX",
       "std": "标准",
       "utage": "宴"
+    },
+    "seo": {
+      "description": "{{title}} / {{artist}} - {{sheetLabel}} 谱面详情、谱面定数与音符数 - DXRating。"
     }
   },
   "about": {

--- a/apps/web/src/locales/resources/zh-Hant.json
+++ b/apps/web/src/locales/resources/zh-Hant.json
@@ -2,11 +2,19 @@
   "root": {
     "pages": {
       "search": {
-        "title": "搜尋譜面"
+        "title": "搜尋譜面",
+        "seo-title": "搜尋譜面",
+        "seo-description": "按歌曲名、藝術家或難度瀏覽所有 maimai DX 譜面，查看譜面定數、音符數和詳細譜面資訊。"
       },
       "rating": {
-        "title": "計算評分"
+        "title": "計算評分",
+        "seo-title": "評分計算器",
+        "seo-description": "在 DXRating 計算和管理你的 maimai DX Rating 記錄、Best 50、達成率和分數詳情。"
       }
+    },
+    "seo": {
+      "description": "DXRating 是 maimai DX Rating 分析工具，也提供譜面詳情等功能。",
+      "keywords": "maimai, maimai DX, maimai DX Rating, maimai DX Rating 分析工具, 中二節奏, 舞萌, 舞萌DX, 譜面詳情, 評分計算器, maimai wiki"
     },
     "share": {
       "copy-content": "{{ link }}",
@@ -174,6 +182,9 @@
       "dx": "DX",
       "std": "標準",
       "utage": "宴"
+    },
+    "seo": {
+      "description": "{{title}} / {{artist}} - {{sheetLabel}} 譜面詳情、譜面定數與音符數 - DXRating。"
     }
   },
   "about": {

--- a/apps/web/src/pages/SongPage.tsx
+++ b/apps/web/src/pages/SongPage.tsx
@@ -7,6 +7,7 @@ import MdiArrowLeft from '~icons/mdi/arrow-left'
 import { TYPE_ORDER, getHighestDifficulty } from '../models/constants'
 import { useAppContextDXDataVersion } from '../models/context/useAppContext'
 import { useServerAliases } from '../models/useServerAliases'
+import { DEFAULT_LOCALE, toSupportedLocale } from '../setup/locale'
 import { type FlattenedSheet, canonicalId, getSearchAcronymsWithServerAliases } from '../songs'
 import { SongHeader } from '../components/song/SongHeader'
 import { SongSheetContent } from '../components/song/SongSheetContent'
@@ -16,7 +17,7 @@ import { getSheetPageTitle } from '../components/song/sheetDisplay'
 const routeApi = getRouteApi('/songs/$songId/$type/$difficulty')
 
 export const SongPage: FC = () => {
-  const { t } = useTranslation(['song'])
+  const { t, i18n } = useTranslation(['song'])
   const { songId, type, difficulty } = routeApi.useParams()
   const navigate = useNavigate()
   const appVersion = useAppContextDXDataVersion()
@@ -69,7 +70,8 @@ export const SongPage: FC = () => {
     (sheet) => sheet.type === activeType && sheet.difficulty === activeDifficulty,
   )
   const headerSheet = activeSheet ?? flattenedSheets[0]
-  const pageTitle = song && activeSheet ? getSheetPageTitle(song, activeSheet) : undefined
+  const locale = toSupportedLocale(i18n.language) ?? DEFAULT_LOCALE
+  const pageTitle = song && activeSheet ? getSheetPageTitle(song, activeSheet, locale) : undefined
 
   const handleTypeChange = (newType: TypeEnum) => {
     const sheetsOfType = flattenedSheets.filter((s) => s.type === newType)

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -18,6 +18,7 @@ import { AppContextProvider } from '@/models/context/AppContext'
 import { RatingCalculatorContextProvider } from '@/models/context/RatingCalculatorContext'
 import { startViewTransition } from '@/utils/startViewTransition'
 import { buildAlternateLinks } from '@/utils/alternateLinks'
+import { buildRootSeoMeta, resolveSeoLocale } from '@/utils/seo'
 import { useVersionTheme } from '@/utils/useVersionTheme'
 import appCss from '@/index.css?url'
 import unoResetCss from '@unocss/reset/tailwind-compat.css?url'
@@ -36,105 +37,89 @@ const fallbackElement = (
 )
 
 export const Route = createRootRoute({
-  head: ({ matches }) => ({
-    meta: [
-      { charSet: 'utf-8' },
-      {
-        name: 'viewport',
-        content: 'width=device-width, initial-scale=1.0, viewport-fit=cover',
-      },
-      ...(matches.some((match) => String(match.routeId) === SONG_DETAIL_ROUTE_ID) ? [] : [{ title: 'DXRating' }]),
-      {
-        name: 'description',
-        content: 'DXRating is a maimai DX Rating analyzer, along with other features like chart details and more.',
-      },
-      {
-        name: 'keywords',
-        content:
-          'maimai, maimai DX, maimai DX Rating, maimai DX Rating analyzer, gekichumai, maimaiでらっくす, 舞萌, 舞萌DX, 舞萌查分器, 舞萌算分器, maimai wiki',
-      },
-      { property: 'og:site_name', content: 'DXRating' },
-      { property: 'og:type', content: 'website' },
-      { property: 'og:title', content: 'DXRating' },
-      {
-        property: 'og:description',
-        content: 'DXRating is a maimai DX Rating analyzer, along with other features like chart details and more.',
-      },
-      {
-        property: 'og:image',
-        content: 'https://shama.dxrating.net/favicon/pack/v1/apple-touch-icon.png',
-      },
-      { property: 'og:url', content: 'https://dxrating.net' },
-      { name: 'twitter:card', content: 'summary' },
-      { name: 'twitter:title', content: 'DXRating' },
-      {
-        name: 'twitter:description',
-        content: 'DXRating is a maimai DX Rating analyzer, along with other features like chart details and more.',
-      },
-      { name: 'theme-color', content: '#c8a8f9' },
-      { name: 'apple-mobile-web-app-capable', content: 'yes' },
-      { name: 'msapplication-TileColor', content: '#c8a8f9' },
-      {
-        name: 'msapplication-config',
-        content: 'https://shama.dxrating.net/favicon/pack/v1/browserconfig.xml',
-      },
-    ],
-    links: [
-      { rel: 'stylesheet', href: unoResetCss },
-      { rel: 'stylesheet', href: appCss },
-      ...buildAlternateLinks({
-        pathname: matches[matches.length - 1]?.pathname ?? '/',
-        search: matches[matches.length - 1]?.search,
-      }),
-      {
-        rel: 'prefetch',
-        href: 'https://shama.dxrating.net/images/version-logo/buddies.webp',
-      },
-      { rel: 'preconnect', href: 'https://miruku.dxrating.net' },
-      {
-        rel: 'apple-touch-icon',
-        sizes: '180x180',
-        href: 'https://shama.dxrating.net/favicon/pack/v1/apple-touch-icon.png',
-      },
-      {
-        rel: 'icon',
-        type: 'image/png',
-        sizes: '32x32',
-        href: 'https://shama.dxrating.net/favicon/pack/v1/favicon-32x32.png',
-      },
-      {
-        rel: 'icon',
-        type: 'image/png',
-        sizes: '16x16',
-        href: 'https://shama.dxrating.net/favicon/pack/v1/favicon-16x16.png',
-      },
-      {
-        rel: 'mask-icon',
-        href: 'https://shama.dxrating.net/favicon/pack/v1/safari-pinned-tab.svg',
-        color: '#c8a8f9',
-      },
-      {
-        rel: 'shortcut icon',
-        href: 'https://shama.dxrating.net/favicon/pack/v1/favicon.ico',
-      },
-      {
-        rel: 'search',
-        type: 'application/opensearchdescription+xml',
-        title: 'DXRating Search',
-        href: 'https://dxrating.net/opensearch.xml',
-      },
-      { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
-      {
-        rel: 'preconnect',
-        href: 'https://fonts.gstatic.com',
-        crossOrigin: 'anonymous',
-      },
-      {
-        rel: 'stylesheet',
-        href: 'https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&display=swap',
-      },
-    ],
+  beforeLoad: (ctx) => ({
+    locale: resolveSeoLocale([
+      { context: (ctx as { serverContext?: unknown }).serverContext },
+      { context: ctx.context },
+    ]),
   }),
+  head: ({ match, matches }) => {
+    const locale = resolveSeoLocale([match, ...matches])
+    const includeRootTitle = !matches.some((match) => String(match.routeId) === SONG_DETAIL_ROUTE_ID)
+
+    return {
+      meta: [
+        { charSet: 'utf-8' },
+        {
+          name: 'viewport',
+          content: 'width=device-width, initial-scale=1.0, viewport-fit=cover',
+        },
+        ...buildRootSeoMeta(locale, { includeTitle: includeRootTitle }),
+        { name: 'theme-color', content: '#c8a8f9' },
+        { name: 'apple-mobile-web-app-capable', content: 'yes' },
+        { name: 'msapplication-TileColor', content: '#c8a8f9' },
+        {
+          name: 'msapplication-config',
+          content: 'https://shama.dxrating.net/favicon/pack/v1/browserconfig.xml',
+        },
+      ],
+      links: [
+        { rel: 'stylesheet', href: unoResetCss },
+        { rel: 'stylesheet', href: appCss },
+        ...buildAlternateLinks({
+          pathname: matches[matches.length - 1]?.pathname ?? '/',
+          search: matches[matches.length - 1]?.search,
+        }),
+        {
+          rel: 'prefetch',
+          href: 'https://shama.dxrating.net/images/version-logo/buddies.webp',
+        },
+        { rel: 'preconnect', href: 'https://miruku.dxrating.net' },
+        {
+          rel: 'apple-touch-icon',
+          sizes: '180x180',
+          href: 'https://shama.dxrating.net/favicon/pack/v1/apple-touch-icon.png',
+        },
+        {
+          rel: 'icon',
+          type: 'image/png',
+          sizes: '32x32',
+          href: 'https://shama.dxrating.net/favicon/pack/v1/favicon-32x32.png',
+        },
+        {
+          rel: 'icon',
+          type: 'image/png',
+          sizes: '16x16',
+          href: 'https://shama.dxrating.net/favicon/pack/v1/favicon-16x16.png',
+        },
+        {
+          rel: 'mask-icon',
+          href: 'https://shama.dxrating.net/favicon/pack/v1/safari-pinned-tab.svg',
+          color: '#c8a8f9',
+        },
+        {
+          rel: 'shortcut icon',
+          href: 'https://shama.dxrating.net/favicon/pack/v1/favicon.ico',
+        },
+        {
+          rel: 'search',
+          type: 'application/opensearchdescription+xml',
+          title: 'DXRating Search',
+          href: 'https://dxrating.net/opensearch.xml',
+        },
+        { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
+        {
+          rel: 'preconnect',
+          href: 'https://fonts.gstatic.com',
+          crossOrigin: 'anonymous',
+        },
+        {
+          rel: 'stylesheet',
+          href: 'https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&display=swap',
+        },
+      ],
+    }
+  },
   component: RootComponent,
 })
 
@@ -284,10 +269,10 @@ function AppLayout() {
 }
 
 function RootDocument({ children }: { children: React.ReactNode }) {
-  const { i18n } = useTranslation()
+  const { locale } = Route.useRouteContext()
 
   return (
-    <html lang={i18n.language}>
+    <html lang={locale}>
       <head>
         <HeadContent />
       </head>

--- a/apps/web/src/routes/rating.tsx
+++ b/apps/web/src/routes/rating.tsx
@@ -1,7 +1,16 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { RatingCalculator } from '@/pages/RatingCalculator'
+import { buildRatingSeo, resolveSeoLocale } from '@/utils/seo'
 
 export const Route = createFileRoute('/rating')({
   ssr: false,
+  head: ({ match, matches }) => {
+    const seo = buildRatingSeo(resolveSeoLocale([match, ...matches]))
+
+    return {
+      meta: seo.meta,
+      links: seo.links,
+    }
+  },
   component: RatingCalculator,
 })

--- a/apps/web/src/routes/search.tsx
+++ b/apps/web/src/routes/search.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { SheetList } from '@/pages/SheetList'
+import { buildSearchSeo, resolveSeoLocale } from '@/utils/seo'
 
 type SearchParams = {
   q?: string
@@ -10,32 +11,14 @@ type SearchParams = {
 
 export const Route = createFileRoute('/search')({
   ssr: false,
-  head: () => ({
-    meta: [
-      { title: 'Charts & Songs — DXRating' },
-      {
-        name: 'description',
-        content:
-          'Browse all maimai DX charts — search by song title, artist, or difficulty. View internal levels, note counts, and detailed chart information.',
-      },
-      { property: 'og:title', content: 'Charts & Songs — DXRating' },
-      {
-        property: 'og:description',
-        content:
-          'Browse all maimai DX charts — search by song title, artist, or difficulty. View internal levels, note counts, and detailed chart information.',
-      },
-      { property: 'og:url', content: 'https://dxrating.net/search' },
-      { property: 'og:type', content: 'website' },
-      { name: 'twitter:card', content: 'summary' },
-      { name: 'twitter:title', content: 'Charts & Songs — DXRating' },
-      {
-        name: 'twitter:description',
-        content:
-          'Browse all maimai DX charts — search by song title, artist, or difficulty. View internal levels, note counts, and detailed chart information.',
-      },
-    ],
-    links: [{ rel: 'canonical', href: 'https://dxrating.net/search' }],
-  }),
+  head: ({ match, matches }) => {
+    const seo = buildSearchSeo(resolveSeoLocale([match, ...matches]))
+
+    return {
+      meta: seo.meta,
+      links: seo.links,
+    }
+  },
   validateSearch: (search: Record<string, unknown>): SearchParams => ({
     q: typeof search.q === 'string' ? search.q : undefined,
     songId: typeof search.songId === 'string' ? search.songId : undefined,

--- a/apps/web/src/routes/songs/$songId/$type/$difficulty.tsx
+++ b/apps/web/src/routes/songs/$songId/$type/$difficulty.tsx
@@ -1,8 +1,8 @@
 import { dxdata } from '@gekichumai/dxdata'
 import { createFileRoute, notFound } from '@tanstack/react-router'
-import { buildSheetLink } from '@/components/sheet/sheetLinks'
-import { getSheetPageTitle, getSheetTitleLabel } from '@/components/song/sheetDisplay'
 import { SongPage } from '@/pages/SongPage'
+import { buildSongSheetSeo, formatSeoTitle, resolveSeoLocale } from '@/utils/seo'
+import { createServerI18n } from '@/setup/init-i18n'
 
 export const Route = createFileRoute('/songs/$songId/$type/$difficulty')({
   ssr: true,
@@ -19,42 +19,21 @@ export const Route = createFileRoute('/songs/$songId/$type/$difficulty')({
 
     return { song, sheet }
   },
-  head: ({ loaderData }) => {
+  head: ({ loaderData, match, matches }) => {
+    const locale = resolveSeoLocale([match, ...matches])
     const song = loaderData?.song
     const sheet = loaderData?.sheet
     if (!song || !sheet) {
       return {
-        meta: [{ title: 'Song Not Found - DXRating' }],
+        meta: [{ title: formatSeoTitle(createServerI18n(locale).t('song:not-found.title')) }],
       }
     }
 
-    const sheetLabel = getSheetTitleLabel(sheet)
-    const pageTitle = getSheetPageTitle(song, sheet)
-    const description = `${song.title} by ${song.artist} - ${sheetLabel} chart details, internal levels, and note counts on DXRating.`
-    const image = `https://shama.dxrating.net/images/cover/v2/${song.imageName}.jpg`
-    const url = buildSheetLink(
-      {
-        songId: song.songId,
-        type: sheet.type,
-        difficulty: sheet.difficulty,
-      },
-      'https://dxrating.net',
-    )
+    const seo = buildSongSheetSeo(song, sheet, locale)
 
     return {
-      meta: [
-        { name: 'description', content: description },
-        { property: 'og:title', content: pageTitle },
-        { property: 'og:description', content: description },
-        { property: 'og:image', content: image },
-        { property: 'og:url', content: url },
-        { property: 'og:type', content: 'website' },
-        { name: 'twitter:card', content: 'summary_large_image' },
-        { name: 'twitter:title', content: pageTitle },
-        { name: 'twitter:description', content: description },
-        { name: 'twitter:image', content: image },
-      ],
-      links: [{ rel: 'canonical', href: url }],
+      meta: seo.meta,
+      links: seo.links,
       scripts: [
         {
           type: 'application/ld+json',
@@ -66,9 +45,10 @@ export const Route = createFileRoute('/songs/$songId/$type/$difficulty')({
               '@type': 'Person',
               name: song.artist,
             },
-            image,
-            url,
+            image: seo.image,
+            url: seo.url,
             genre: song.category,
+            inLanguage: locale,
             isPartOf: {
               '@type': 'WebSite',
               name: 'DXRating',

--- a/apps/web/src/setup/__tests__/sentry-start.test.ts
+++ b/apps/web/src/setup/__tests__/sentry-start.test.ts
@@ -6,10 +6,11 @@ describe('TanStack Start Sentry integration', () => {
   it('registers Sentry before local request and function middleware', () => {
     const options = buildStartOptions()
 
-    expect(options.requestMiddleware).toHaveLength(2)
+    expect(options.requestMiddleware).toHaveLength(3)
     expect(options.functionMiddleware).toHaveLength(1)
     expect(options.requestMiddleware[0]).toBe(sentryGlobalRequestMiddleware)
     expect(options.requestMiddleware[1]).not.toBe(sentryGlobalRequestMiddleware)
+    expect(options.requestMiddleware[2]).not.toBe(sentryGlobalRequestMiddleware)
     expect(options.functionMiddleware[0]).toBe(sentryGlobalFunctionMiddleware)
   })
 })

--- a/apps/web/src/start.ts
+++ b/apps/web/src/start.ts
@@ -1,6 +1,18 @@
 import { sentryGlobalFunctionMiddleware, sentryGlobalRequestMiddleware } from '@sentry/tanstackstart-react'
 import { createMiddleware, createStart } from '@tanstack/react-start'
+import { appendVaryHeader, detectServerLocale } from './setup/locale'
 import { applySecurityReportHeaders } from './setup/security-headers'
+
+const localeMiddleware = createMiddleware().server(async ({ request, next }) => {
+  const locale = detectServerLocale(request)
+  const result = await next({ context: { locale } })
+
+  result.response.headers.set('Content-Language', locale)
+  appendVaryHeader(result.response.headers, 'Cookie')
+  appendVaryHeader(result.response.headers, 'Accept-Language')
+
+  return result
+})
 
 const securityReportHeadersMiddleware = createMiddleware().server(async ({ next }) => {
   const result = await next()
@@ -12,7 +24,7 @@ const securityReportHeadersMiddleware = createMiddleware().server(async ({ next 
 
 export function buildStartOptions() {
   return {
-    requestMiddleware: [sentryGlobalRequestMiddleware, securityReportHeadersMiddleware],
+    requestMiddleware: [sentryGlobalRequestMiddleware, localeMiddleware, securityReportHeadersMiddleware],
     functionMiddleware: [sentryGlobalFunctionMiddleware],
   }
 }

--- a/apps/web/src/utils/__tests__/seo.test.ts
+++ b/apps/web/src/utils/__tests__/seo.test.ts
@@ -1,0 +1,61 @@
+import { DifficultyEnum, TypeEnum } from '@gekichumai/dxdata'
+import { describe, expect, it } from 'vitest'
+import { buildRootSeoMeta, buildSearchSeo, buildSongSheetSeo, resolveSeoLocale } from '../seo'
+
+describe('SEO localization', () => {
+  it('resolves the locale from route server context before falling back to English', () => {
+    expect(
+      resolveSeoLocale([
+        {
+          context: {
+            serverContext: {
+              locale: 'ja',
+            },
+          },
+        },
+      ]),
+    ).toBe('ja')
+  })
+
+  it('builds localized root metadata for HTML responses', () => {
+    const meta = buildRootSeoMeta('zh-Hans')
+
+    expect(meta).toContainEqual({
+      name: 'description',
+      content: 'DXRating 是 maimai DX Rating 分析工具，也提供谱面详情等功能。',
+    })
+    expect(meta).toContainEqual({
+      property: 'og:description',
+      content: 'DXRating 是 maimai DX Rating 分析工具，也提供谱面详情等功能。',
+    })
+  })
+
+  it('builds localized search route metadata', () => {
+    expect(buildSearchSeo('ja').title).toBe('譜面検索 - DXRating')
+    expect(buildSearchSeo('ja').description).toBe(
+      'maimai DX の譜面を、楽曲名、アーティスト、難易度から検索できます。譜面定数、ノーツ数、詳しい譜面情報も確認できます。',
+    )
+  })
+
+  it('builds localized song sheet title and social metadata', () => {
+    const seo = buildSongSheetSeo(
+      {
+        title: 'Test Song',
+        artist: 'Test Artist',
+        category: 'POPSアニメ',
+        imageName: 'test-song',
+        songId: 'test-song',
+      },
+      {
+        type: TypeEnum.STD,
+        difficulty: DifficultyEnum.Master,
+      },
+      'zh-Hant',
+    )
+
+    expect(seo.title).toBe('Test Song [標準 MASTER] - DXRating')
+    expect(seo.description).toBe('Test Song / Test Artist - 標準 MASTER 譜面詳情、譜面定數與音符數 - DXRating。')
+    expect(seo.meta).toContainEqual({ property: 'og:title', content: seo.title })
+    expect(seo.meta).toContainEqual({ name: 'twitter:description', content: seo.description })
+  })
+})

--- a/apps/web/src/utils/seo.ts
+++ b/apps/web/src/utils/seo.ts
@@ -1,0 +1,195 @@
+import { TypeEnum, type DifficultyEnum } from '@gekichumai/dxdata'
+import type { SupportedLocale } from '@/setup/locale'
+import { DEFAULT_LOCALE, toSupportedLocale } from '@/setup/locale'
+import { createServerI18n } from '@/setup/init-i18n'
+import { buildSheetLink } from '@/components/sheet/sheetLinks'
+import { getSheetPageTitle, getSheetTitleLabel } from '@/components/song/sheetDisplay'
+
+type SeoMeta =
+  | { title: string }
+  | { name: string; content: string }
+  | { property: string; content: string }
+  | { charSet: string }
+
+type SeoRouteMatch = {
+  context?: unknown
+  search?: unknown
+}
+
+const OG_LOCALES: Record<SupportedLocale, string> = {
+  en: 'en_US',
+  ja: 'ja_JP',
+  'zh-Hans': 'zh_CN',
+  'zh-Hant': 'zh_TW',
+}
+
+const i18nCache = new Map<SupportedLocale, ReturnType<typeof createServerI18n>>()
+
+function getSeoI18n(locale: SupportedLocale) {
+  const cached = i18nCache.get(locale)
+  if (cached) return cached
+
+  const instance = createServerI18n(locale)
+  i18nCache.set(locale, instance)
+  return instance
+}
+
+function t(locale: SupportedLocale, key: string, values?: Record<string, unknown>) {
+  return getSeoI18n(locale).t(key, values)
+}
+
+function readLocaleFromContext(context: unknown): SupportedLocale | null {
+  if (typeof context !== 'object' || context === null) return null
+
+  const record = context as Record<string, unknown>
+  return toSupportedLocale(record.locale as string | undefined) ?? readLocaleFromContext(record.serverContext)
+}
+
+function readLocaleFromSearch(search: unknown): SupportedLocale | null {
+  if (typeof search !== 'object' || search === null) return null
+
+  return toSupportedLocale((search as Record<string, unknown>).locale as string | undefined)
+}
+
+export function resolveSeoLocale(matches?: readonly SeoRouteMatch[]): SupportedLocale {
+  for (const match of [...(matches ?? [])].reverse()) {
+    const locale = readLocaleFromContext(match.context) ?? readLocaleFromSearch(match.search)
+    if (locale) return locale
+  }
+
+  if (typeof document !== 'undefined') {
+    return toSupportedLocale(document.documentElement.lang) ?? DEFAULT_LOCALE
+  }
+
+  return DEFAULT_LOCALE
+}
+
+export function formatSeoTitle(title: string) {
+  return `${title} - DXRating`
+}
+
+export function buildRootSeoMeta(locale: SupportedLocale, options: { includeTitle?: boolean } = {}): SeoMeta[] {
+  const includeTitle = options.includeTitle ?? true
+  const title = 'DXRating'
+  const description = t(locale, 'root:seo.description')
+
+  return [
+    ...(includeTitle ? [{ title }] : []),
+    { name: 'description', content: description },
+    { name: 'keywords', content: t(locale, 'root:seo.keywords') },
+    { property: 'og:site_name', content: 'DXRating' },
+    { property: 'og:locale', content: OG_LOCALES[locale] },
+    { property: 'og:type', content: 'website' },
+    { property: 'og:title', content: title },
+    { property: 'og:description', content: description },
+    {
+      property: 'og:image',
+      content: 'https://shama.dxrating.net/favicon/pack/v1/apple-touch-icon.png',
+    },
+    { property: 'og:url', content: 'https://dxrating.net' },
+    { name: 'twitter:card', content: 'summary' },
+    { name: 'twitter:title', content: title },
+    { name: 'twitter:description', content: description },
+  ]
+}
+
+export function buildSearchSeo(locale: SupportedLocale) {
+  const title = formatSeoTitle(t(locale, 'root:pages.search.seo-title'))
+  const description = t(locale, 'root:pages.search.seo-description')
+
+  return {
+    title,
+    description,
+    meta: [
+      { title },
+      { name: 'description', content: description },
+      { property: 'og:title', content: title },
+      { property: 'og:description', content: description },
+      { property: 'og:url', content: 'https://dxrating.net/search' },
+      { property: 'og:type', content: 'website' },
+      { property: 'og:locale', content: OG_LOCALES[locale] },
+      { name: 'twitter:card', content: 'summary' },
+      { name: 'twitter:title', content: title },
+      { name: 'twitter:description', content: description },
+    ] satisfies SeoMeta[],
+    links: [{ rel: 'canonical', href: 'https://dxrating.net/search' }],
+  }
+}
+
+export function buildRatingSeo(locale: SupportedLocale) {
+  const title = formatSeoTitle(t(locale, 'root:pages.rating.seo-title'))
+  const description = t(locale, 'root:pages.rating.seo-description')
+
+  return {
+    title,
+    description,
+    meta: [
+      { title },
+      { name: 'description', content: description },
+      { property: 'og:title', content: title },
+      { property: 'og:description', content: description },
+      { property: 'og:url', content: 'https://dxrating.net/rating' },
+      { property: 'og:type', content: 'website' },
+      { property: 'og:locale', content: OG_LOCALES[locale] },
+      { name: 'twitter:card', content: 'summary' },
+      { name: 'twitter:title', content: title },
+      { name: 'twitter:description', content: description },
+    ] satisfies SeoMeta[],
+    links: [{ rel: 'canonical', href: 'https://dxrating.net/rating' }],
+  }
+}
+
+export function buildSongSheetSeo(
+  song: {
+    title: string
+    artist: string
+    category: string
+    imageName: string
+    songId: string
+  },
+  sheet: {
+    type: TypeEnum
+    difficulty: DifficultyEnum | string
+  },
+  locale: SupportedLocale,
+) {
+  const sheetLabel = getSheetTitleLabel(sheet, locale)
+  const title = getSheetPageTitle(song, sheet, locale)
+  const description = t(locale, 'song:seo.description', {
+    title: song.title,
+    artist: song.artist,
+    sheetLabel,
+  })
+  const image = `https://shama.dxrating.net/images/cover/v2/${song.imageName}.jpg`
+  const url = buildSheetLink(
+    {
+      songId: song.songId,
+      type: sheet.type,
+      difficulty: sheet.difficulty,
+    },
+    'https://dxrating.net',
+  )
+
+  return {
+    title,
+    sheetLabel,
+    description,
+    image,
+    url,
+    meta: [
+      { title },
+      { name: 'description', content: description },
+      { property: 'og:title', content: title },
+      { property: 'og:description', content: description },
+      { property: 'og:image', content: image },
+      { property: 'og:url', content: url },
+      { property: 'og:type', content: 'website' },
+      { property: 'og:locale', content: OG_LOCALES[locale] },
+      { name: 'twitter:card', content: 'summary_large_image' },
+      { name: 'twitter:title', content: title },
+      { name: 'twitter:description', content: description },
+      { name: 'twitter:image', content: image },
+    ] satisfies SeoMeta[],
+    links: [{ rel: 'canonical', href: url }],
+  }
+}


### PR DESCRIPTION
## Summary
- Add locale-aware SEO helpers for root, search, rating, and song sheet routes.
- Propagate server-detected locale into the HTML `lang` attribute and response headers.
- Localize song page titles and descriptions, including UTAGE custom difficulty link handling.
- Add tests for SEO helpers, sheet link generation, and Sentry middleware registration.

## Testing
- Added/updated unit coverage for SEO locale resolution, localized metadata generation, and UTAGE sheet links.
- Not run (not requested).