### PR TITLE
[codex] Add chart OG image renderer

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -28,6 +28,7 @@
     "@scalar/hono-api-reference": "^0.10.8",
     "@sentry/node": "^10.34.0",
     "@simplewebauthn/server": "^13.3.0",
+    "@takumi-rs/image-response": "1.1.2",
     "@types/react": "catalog:",
     "bcrypt": "^6.0.0",
     "better-auth": "catalog:",

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -5,6 +5,7 @@ import { createMiddleware } from 'hono/factory'
 import { cors } from 'hono/cors'
 import { z } from 'zod'
 import { auth } from './auth.js'
+import { handler as chartOgImageRenderer } from './services/functions/chart-og-image/index.js'
 import { handler as oneshotRenderer } from './services/functions/oneshot-renderer/index.js'
 import {
   v0Handler as fetchNetRecordsV0Handler,
@@ -168,6 +169,7 @@ app.post('/api/v1/monitoring/tunnel', async (c) => {
 app.post('/functions/fetch-net-records/v0', verifyParams, fetchNetRecordsV0Handler)
 app.post('/functions/fetch-net-records/v1/:region', verifyParams, fetchNetRecordsV1Handler)
 app.post('/functions/render-oneshot/v0', oneshotRenderer)
+app.get('/functions/render-chart-og/v0/:songId/:type/:difficulty', chartOgImageRenderer)
 
 // LXNS OAuth callback (direct Hono route — must be before oRPC catch-all since it redirects)
 app.get('/api/v1/io/import/lxns/oauth_callback', async (c) => {

--- a/apps/backend/src/services/functions/chart-og-image/index.tsx
+++ b/apps/backend/src/services/functions/chart-og-image/index.tsx
@@ -1,0 +1,487 @@
+import { DifficultyEnum, TypeEnum, dxdata } from '@gekichumai/dxdata'
+import type { NoteCounts } from '@gekichumai/dxdata'
+import { ImageResponse } from '@takumi-rs/image-response'
+import type { Handler } from 'hono'
+import type { CSSProperties, ReactNode } from 'react'
+import { fetchAsset, fetchImageAsset } from '../oneshot-renderer/assetFetcher.js'
+
+export const CHART_OG_IMAGE_WIDTH = 1200
+export const CHART_OG_IMAGE_HEIGHT = 630
+const ASSET_ORIGIN = 'https://shama.dxrating.net'
+const FRONTEND_ORIGIN = 'https://dxrating.net'
+
+const CACHE_CONTROL = 'public, max-age=86400, s-maxage=604800, stale-while-revalidate=604800'
+
+type DifficultyDisplay = {
+  title: string
+  color: string
+  textColor: string
+}
+
+const DIFFICULTY_DISPLAY: Record<DifficultyEnum, DifficultyDisplay> = {
+  [DifficultyEnum.Basic]: { title: 'BASIC', color: '#22bb5b', textColor: '#ffffff' },
+  [DifficultyEnum.Advanced]: { title: 'ADVANCED', color: '#fb9c2d', textColor: '#111827' },
+  [DifficultyEnum.Expert]: { title: 'EXPERT', color: '#f64861', textColor: '#ffffff' },
+  [DifficultyEnum.Master]: { title: 'MASTER', color: '#9e45e2', textColor: '#ffffff' },
+  [DifficultyEnum.ReMaster]: { title: 'Re:MASTER', color: '#ba67f8', textColor: '#ffffff' },
+}
+
+const TYPE_DISPLAY: Record<TypeEnum, string> = {
+  [TypeEnum.DX]: 'DX',
+  [TypeEnum.STD]: 'Standard',
+  [TypeEnum.UTAGE]: 'Utage',
+  [TypeEnum.UTAGE2P]: 'Utage',
+}
+
+export type ChartOgImageData = {
+  songId: string
+  title: string
+  artist: string
+  category: string
+  imageName: string
+  coverUrl: string
+  detailUrl: string
+  type: TypeEnum
+  typeLabel: string
+  difficulty: DifficultyEnum
+  difficultyLabel: string
+  difficultyColor: string
+  difficultyTextColor: string
+  level: string
+  levelLabel: string
+  internalLevelValue: number
+  noteDesigner: string | null
+  noteCounts: NoteCounts
+  version: string
+}
+
+export type RenderChartOgImage = (data: ChartOgImageData) => Promise<ArrayBuffer | Uint8Array>
+
+export function buildChartOgDetailUrl(songId: string, type: string, difficulty: string) {
+  return `${FRONTEND_ORIGIN}/songs/${encodeURIComponent(songId)}/${encodeURIComponent(type)}/${encodeURIComponent(difficulty)}`
+}
+
+export function formatInternalLevelLabelParts(internalLevelValue: number) {
+  const [integer = '0', fraction = '0'] = internalLevelValue.toFixed(1).split('.')
+  return {
+    prefix: 'Lv ',
+    integer,
+    fraction: `.${fraction}`,
+  }
+}
+
+export function resolveChartOgImageData(songId: string, type: string, difficulty: string): ChartOgImageData | null {
+  const song = dxdata.songs.find((candidate) => candidate.songId === songId)
+  if (!song) return null
+
+  const sheet = song.sheets.find((candidate) => candidate.type === type && candidate.difficulty === difficulty)
+  if (!sheet) return null
+
+  const difficultyDisplay = DIFFICULTY_DISPLAY[sheet.difficulty]
+  const levelParts = formatInternalLevelLabelParts(sheet.internalLevelValue)
+
+  return {
+    songId: song.songId,
+    title: song.title,
+    artist: song.artist,
+    category: song.category,
+    imageName: song.imageName,
+    coverUrl: `${ASSET_ORIGIN}/images/cover/v2/${song.imageName}.jpg`,
+    detailUrl: buildChartOgDetailUrl(song.songId, sheet.type, sheet.difficulty),
+    type: sheet.type,
+    typeLabel: TYPE_DISPLAY[sheet.type],
+    difficulty: sheet.difficulty,
+    difficultyLabel: difficultyDisplay.title,
+    difficultyColor: difficultyDisplay.color,
+    difficultyTextColor: difficultyDisplay.textColor,
+    level: sheet.level,
+    levelLabel: `${levelParts.prefix}${levelParts.integer}${levelParts.fraction}`,
+    internalLevelValue: sheet.internalLevelValue,
+    noteDesigner: sheet.noteDesigner,
+    noteCounts: sheet.noteCounts,
+    version: sheet.version,
+  }
+}
+
+export function createChartOgImageHandler(renderImage: RenderChartOgImage = renderChartOgImage): Handler {
+  return async (c) => {
+    const songId = c.req.param('songId')
+    const type = c.req.param('type')
+    const difficulty = c.req.param('difficulty')
+    if (!songId || !type || !difficulty) return c.text('Chart not found', 404)
+
+    const data = resolveChartOgImageData(songId, type, difficulty)
+    if (!data) return c.text('Chart not found', 404)
+
+    const image = await renderImage(data)
+    const body = toArrayBuffer(image)
+    return new Response(body, {
+      headers: {
+        'Cache-Control': CACHE_CONTROL,
+        'Content-Length': String(image.byteLength),
+        'Content-Type': 'image/png',
+      },
+    })
+  }
+}
+
+function toArrayBuffer(image: ArrayBuffer | Uint8Array): ArrayBuffer {
+  if (image instanceof ArrayBuffer) return image
+  return image.buffer.slice(image.byteOffset, image.byteOffset + image.byteLength) as ArrayBuffer
+}
+
+type TakumiFont = {
+  name: string
+  data: Buffer
+  weight: number
+  style: 'normal'
+}
+
+const fontConfig = [
+  { name: 'Source Han Sans', file: 'SourceHanSansJP-Regular.otf', weight: 400 },
+  { name: 'Source Han Sans', file: 'SourceHanSansJP-Bold.otf', weight: 700 },
+] as const
+
+let cachedFonts: TakumiFont[] | null = null
+
+async function loadFonts(): Promise<TakumiFont[]> {
+  if (cachedFonts) return cachedFonts
+
+  cachedFonts = await Promise.all(
+    fontConfig.map(async (font) => ({
+      name: font.name,
+      data: await fetchAsset(`/fonts/${font.file}`),
+      weight: font.weight,
+      style: 'normal' as const,
+    })),
+  )
+  return cachedFonts
+}
+
+function dataUri(mimeType: 'image/jpeg' | 'image/png', data: Buffer) {
+  return `data:${mimeType};base64,${data.toString('base64')}`
+}
+
+async function loadCoverDataUri(imageName: string) {
+  const cover = await fetchImageAsset(`/images/cover/v2/${imageName}.jpg`)
+  return dataUri('image/jpeg', cover)
+}
+
+async function loadTypeBadgeDataUri(type: TypeEnum) {
+  if (type !== TypeEnum.DX) return null
+
+  const typeImage = await fetchImageAsset('/images/type_dx.png')
+  return dataUri('image/png', typeImage)
+}
+
+export async function renderChartOgImage(data: ChartOgImageData): Promise<Uint8Array> {
+  const [fonts, coverSrc, typeBadgeSrc] = await Promise.all([
+    loadFonts(),
+    loadCoverDataUri(data.imageName),
+    loadTypeBadgeDataUri(data.type),
+  ])
+  const response = new ImageResponse(<ChartOgCard data={data} coverSrc={coverSrc} typeBadgeSrc={typeBadgeSrc} />, {
+    width: CHART_OG_IMAGE_WIDTH,
+    height: CHART_OG_IMAGE_HEIGHT,
+    format: 'png',
+    fonts,
+    emoji: 'twemoji',
+  })
+
+  await response.ready
+  return new Uint8Array(await response.arrayBuffer())
+}
+
+function ChartOgCard({
+  data,
+  coverSrc,
+  typeBadgeSrc,
+}: {
+  data: ChartOgImageData
+  coverSrc: string
+  typeBadgeSrc: string | null
+}) {
+  const titleLayout = getTitleLayout(data.title)
+
+  return (
+    <div style={styles.canvas}>
+      <div style={styles.accentBar} />
+      <div style={styles.coverFrame}>
+        <img alt="" src={coverSrc} width={440} height={440} style={styles.coverImage} />
+      </div>
+
+      <div style={styles.content}>
+        <div style={styles.category}>{data.category}</div>
+        <div style={{ ...styles.title, ...titleLayout }}>{data.title}</div>
+        <div style={styles.artist}>{data.artist}</div>
+
+        <div style={styles.badges}>
+          {typeBadgeSrc ? (
+            <img alt="" src={typeBadgeSrc} height={45} style={styles.typeImage} />
+          ) : (
+            <Badge background="#111827" color="#ffffff">
+              {data.typeLabel}
+            </Badge>
+          )}
+          <DifficultyBadge
+            background={data.difficultyColor}
+            color={data.difficultyTextColor}
+            difficultyLabel={data.difficultyLabel}
+            internalLevelValue={data.internalLevelValue}
+          />
+        </div>
+
+        <div style={styles.statsGrid}>
+          <Stat label="Version" value={data.version} />
+          <Stat label="Designer" value={data.noteDesigner ?? 'Unknown'} />
+        </div>
+
+        <div style={styles.noteCounts}>
+          <NoteCount label="TAP" value={data.noteCounts.tap} />
+          <NoteCount label="HOLD" value={data.noteCounts.hold} />
+          <NoteCount label="SLIDE" value={data.noteCounts.slide} />
+          <NoteCount label="TOUCH" value={data.noteCounts.touch} />
+          <NoteCount label="BREAK" value={data.noteCounts.break} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Badge({ background, color, children }: { background: string; color: string; children: ReactNode }) {
+  return <div style={{ ...styles.badge, backgroundColor: background, color }}>{children}</div>
+}
+
+function DifficultyBadge({
+  background,
+  color,
+  difficultyLabel,
+  internalLevelValue,
+}: {
+  background: string
+  color: string
+  difficultyLabel: string
+  internalLevelValue: number
+}) {
+  const level = formatInternalLevelLabelParts(internalLevelValue)
+
+  return (
+    <div style={{ ...styles.badge, ...styles.difficultyBadge, backgroundColor: background, color }}>
+      <span style={styles.difficultyText}>{difficultyLabel}</span>
+      <hr style={styles.difficultyDivider} />
+      <span style={styles.levelPrefix}>{level.prefix}</span>
+      <span style={styles.levelInteger}>{level.integer}</span>
+      <span style={styles.levelFraction}>{level.fraction}</span>
+    </div>
+  )
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={styles.stat}>
+      <div style={styles.statLabel}>{label}</div>
+      <div style={styles.statValue}>{value}</div>
+    </div>
+  )
+}
+
+function NoteCount({ label, value }: { label: string; value: number | null }) {
+  return (
+    <div style={styles.noteCount}>
+      <span style={styles.noteCountLabel}>{label}</span>
+      <span style={styles.noteCountValue}>{value ?? '-'}</span>
+    </div>
+  )
+}
+
+export function getTitleLayout(title: string): Pick<CSSProperties, 'fontSize' | 'lineHeight' | 'maxHeight'> {
+  if (title.length > 120) return { fontSize: 25, lineHeight: 1.1, maxHeight: 150 }
+  if (title.length > 96) return { fontSize: 28, lineHeight: 1.12, maxHeight: 142 }
+  if (title.length > 64) return { fontSize: 31, lineHeight: 1.14, maxHeight: 136 }
+  if (title.length > 48) return { fontSize: 36, lineHeight: 1.18, maxHeight: 132 }
+  if (title.length > 34) return { fontSize: 42, lineHeight: 1.2, maxHeight: 132 }
+  return { fontSize: 50, lineHeight: 1.22, maxHeight: 132 }
+}
+
+const styles = {
+  canvas: {
+    position: 'relative',
+    display: 'flex',
+    width: '100%',
+    height: '100%',
+    backgroundColor: '#ffffff',
+    color: '#111827',
+    fontFamily: 'Source Han Sans',
+    overflow: 'hidden',
+  },
+  accentBar: {
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    bottom: 0,
+    width: 14,
+    background: 'linear-gradient(180deg, #8b5cf6 0%, #06b6d4 100%)',
+  },
+  coverFrame: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 534,
+    height: '100%',
+    paddingLeft: 70,
+    paddingRight: 24,
+  },
+  coverImage: {
+    width: 440,
+    height: 440,
+    objectFit: 'cover',
+    borderRadius: 40,
+    boxShadow:
+      '0 1px 1px rgba(17, 24, 39, 0.06), 0 4px 8px rgba(17, 24, 39, 0.08), 0 12px 24px rgba(17, 24, 39, 0.10), 0 28px 56px rgba(17, 24, 39, 0.14), 0 48px 96px rgba(17, 24, 39, 0.10), inset 0 0 0 1px rgba(0, 0, 0, 0.10)',
+  },
+  content: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'flex-start',
+    width: 610,
+    height: '100%',
+    paddingTop: 95,
+    paddingRight: 62,
+    paddingBottom: 42,
+    paddingLeft: 20,
+  },
+  category: {
+    color: '#6b7280',
+    fontSize: 20,
+    fontWeight: 700,
+    lineHeight: 1,
+    marginBottom: 12,
+  },
+  title: {
+    color: '#111827',
+    fontWeight: 700,
+    marginBottom: 12,
+    overflow: 'hidden',
+    overflowWrap: 'anywhere',
+  },
+  artist: {
+    color: '#4b5563',
+    fontSize: 24,
+    fontWeight: 400,
+    lineHeight: 1.2,
+    marginBottom: 20,
+    maxHeight: 58,
+    overflow: 'hidden',
+  },
+  badges: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 12,
+    marginBottom: 22,
+  },
+  difficultyBadge: {
+    fontSize: 19,
+    padding: '6px 15px 8px',
+    boxShadow: '3px 3px 0 rgba(11, 56, 113, 0.30)',
+    transform: 'translateY(-3px)',
+  },
+  badge: {
+    display: 'flex',
+    alignItems: 'center',
+    borderRadius: 999,
+    fontSize: 20,
+    fontWeight: 700,
+    lineHeight: 1,
+    padding: '8px 16px',
+  },
+  typeImage: {
+    height: 45,
+    width: 102,
+    objectFit: 'contain',
+  },
+  difficultyText: {
+    fontSize: 19,
+    fontWeight: 700,
+    lineHeight: 1,
+  },
+  difficultyDivider: {
+    width: 1,
+    height: 16,
+    border: 0,
+    backgroundColor: '#ffffff',
+    opacity: 0.62,
+    marginTop: 0,
+    marginRight: 11,
+    marginBottom: 0,
+    marginLeft: 11,
+  },
+  levelPrefix: {
+    fontSize: 19,
+    fontWeight: 400,
+    lineHeight: 1,
+  },
+  levelInteger: {
+    fontSize: 19,
+    fontWeight: 400,
+    lineHeight: 1,
+  },
+  levelFraction: {
+    fontSize: 19,
+    fontWeight: 400,
+    lineHeight: 1,
+  },
+  statsGrid: {
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
+    gap: 18,
+    marginBottom: 20,
+  },
+  stat: {
+    display: 'flex',
+    flexDirection: 'column',
+    minWidth: 0,
+    padding: 0,
+  },
+  statLabel: {
+    color: '#6b7280',
+    fontSize: 14,
+    fontWeight: 700,
+    lineHeight: 1,
+    marginBottom: 7,
+  },
+  statValue: {
+    color: '#111827',
+    fontSize: 21,
+    fontWeight: 400,
+    lineHeight: 1.16,
+    maxHeight: 50,
+    overflow: 'hidden',
+  },
+  noteCounts: {
+    display: 'flex',
+    gap: 10,
+  },
+  noteCount: {
+    display: 'flex',
+    alignItems: 'center',
+    borderRadius: 12,
+    backgroundColor: '#eef2ff',
+    color: '#312e81',
+    lineHeight: 1,
+    padding: '7px 10px',
+    boxShadow: '3px 3px 0 rgba(49, 46, 129, 0.10)',
+  },
+  noteCountLabel: {
+    fontSize: 14,
+    fontWeight: 700,
+    lineHeight: 1,
+    marginRight: 7,
+  },
+  noteCountValue: {
+    fontSize: 18,
+    fontWeight: 400,
+    lineHeight: 1,
+  },
+} satisfies Record<string, CSSProperties>
+
+export const handler = createChartOgImageHandler()

--- a/apps/backend/src/test/chart-og-image.test.ts
+++ b/apps/backend/src/test/chart-og-image.test.ts
@@ -1,0 +1,80 @@
+import { DifficultyEnum, TypeEnum, dxdata } from '@gekichumai/dxdata'
+import { Hono } from 'hono'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createChartOgImageHandler,
+  formatInternalLevelLabelParts,
+  getTitleLayout,
+} from '../services/functions/chart-og-image/index.js'
+
+const song = dxdata.songs.find((candidate) =>
+  candidate.sheets.some((sheet) => sheet.type === TypeEnum.DX && sheet.difficulty === DifficultyEnum.Master),
+)
+
+if (!song) throw new Error('Expected fixture song with a DX Master chart')
+
+const sheet = song.sheets.find(
+  (candidate) => candidate.type === TypeEnum.DX && candidate.difficulty === DifficultyEnum.Master,
+)
+
+if (!sheet) throw new Error('Expected fixture song to include selected sheet')
+
+describe('chart OG image handler', () => {
+  it('resolves chart data and returns a cacheable PNG response', async () => {
+    const image = new Uint8Array([137, 80, 78, 71])
+    const renderImage = vi.fn(async () => image)
+    const app = new Hono()
+    app.get('/og/:songId/:type/:difficulty', createChartOgImageHandler(renderImage))
+
+    const res = await app.request(`/og/${encodeURIComponent(song.songId)}/${sheet.type}/${sheet.difficulty}`)
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('image/png')
+    expect(res.headers.get('cache-control')).toContain('public')
+    expect(await res.arrayBuffer()).toEqual(image.buffer)
+    expect(renderImage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        artist: song.artist,
+        coverUrl: `https://shama.dxrating.net/images/cover/v2/${song.imageName}.jpg`,
+        detailUrl: `https://dxrating.net/songs/${encodeURIComponent(song.songId)}/${sheet.type}/${sheet.difficulty}`,
+        difficulty: sheet.difficulty,
+        levelLabel: `Lv ${sheet.internalLevelValue.toFixed(1)}`,
+        level: sheet.level,
+        songId: song.songId,
+        title: song.title,
+        type: sheet.type,
+      }),
+    )
+  })
+
+  it('returns 404 without rendering when the chart does not exist', async () => {
+    const renderImage = vi.fn(async () => new Uint8Array([1]))
+    const app = new Hono()
+    app.get('/og/:songId/:type/:difficulty', createChartOgImageHandler(renderImage))
+
+    const res = await app.request(
+      `/og/${encodeURIComponent(song.songId)}/${TypeEnum.DX}/${DifficultyEnum.Basic}-missing`,
+    )
+
+    expect(res.status).toBe(404)
+    expect(renderImage).not.toHaveBeenCalled()
+  })
+})
+
+describe('chart OG image level label', () => {
+  it('splits the decimal part for separate visual emphasis', () => {
+    expect(formatInternalLevelLabelParts(12)).toEqual({ prefix: 'Lv ', integer: '12', fraction: '.0' })
+    expect(formatInternalLevelLabelParts(13.7)).toEqual({ prefix: 'Lv ', integer: '13', fraction: '.7' })
+  })
+})
+
+describe('chart OG image title layout', () => {
+  it('uses a compact layout for the longest song title in dxdata', () => {
+    const [longestSong] = [...dxdata.songs].sort((a, b) => b.title.length - a.title.length)
+
+    expect(longestSong.title).toBe(
+      'False Amber (from the Black Bazaar, Or by A Kervan Trader from the Lands Afar, Or Buried Beneath the Shifting Sands That Lead Everywhere but Nowhere)',
+    )
+    expect(getTitleLayout(longestSong.title)).toEqual({ fontSize: 25, lineHeight: 1.1, maxHeight: 150 })
+  })
+})

--- a/apps/web/src/routes/-chart-og-meta.ts
+++ b/apps/web/src/routes/-chart-og-meta.ts
@@ -1,0 +1,30 @@
+import type { DifficultyEnum, TypeEnum } from '@gekichumai/dxdata'
+import { getSheetTitleLabel } from '@/components/song/sheetDisplay'
+
+const CHART_OG_IMAGE_ORIGIN = 'https://miruku.dxrating.net'
+
+export function buildChartOgImageUrl({
+  songId,
+  type,
+  difficulty,
+}: {
+  songId: string
+  type: TypeEnum | string
+  difficulty: DifficultyEnum | string
+}) {
+  return `${CHART_OG_IMAGE_ORIGIN}/functions/render-chart-og/v0/${encodeURIComponent(songId)}/${encodeURIComponent(type)}/${encodeURIComponent(difficulty)}`
+}
+
+export function buildChartOgImageAlt({
+  title,
+  artist,
+  type,
+  difficulty,
+}: {
+  title: string
+  artist: string
+  type: TypeEnum
+  difficulty: DifficultyEnum
+}) {
+  return `${title} by ${artist} - ${getSheetTitleLabel({ type, difficulty })} chart on DXRating`
+}

--- a/apps/web/src/routes/__tests__/-chart-og-meta.test.ts
+++ b/apps/web/src/routes/__tests__/-chart-og-meta.test.ts
@@ -1,0 +1,28 @@
+import { DifficultyEnum, TypeEnum } from '@gekichumai/dxdata'
+import { describe, expect, it } from 'vitest'
+import { buildChartOgImageAlt, buildChartOgImageUrl } from '../-chart-og-meta'
+
+describe('chart OG metadata helpers', () => {
+  it('builds a backend image URL that keeps special song ids path-safe', () => {
+    expect(
+      buildChartOgImageUrl({
+        songId: '1/3の純情な感情 & <test>',
+        type: TypeEnum.DX,
+        difficulty: DifficultyEnum.Master,
+      }),
+    ).toBe(
+      'https://miruku.dxrating.net/functions/render-chart-og/v0/1%2F3%E3%81%AE%E7%B4%94%E6%83%85%E3%81%AA%E6%84%9F%E6%83%85%20%26%20%3Ctest%3E/dx/master',
+    )
+  })
+
+  it('describes the chart image for social previews', () => {
+    expect(
+      buildChartOgImageAlt({
+        title: 'Song Title',
+        artist: 'Composer',
+        type: TypeEnum.STD,
+        difficulty: DifficultyEnum.Expert,
+      }),
+    ).toBe('Song Title by Composer - Standard EXPERT chart on DXRating')
+  })
+})

--- a/apps/web/src/routes/songs/$songId/$type/$difficulty.tsx
+++ b/apps/web/src/routes/songs/$songId/$type/$difficulty.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, notFound } from '@tanstack/react-router'
 import { buildSheetLink } from '@/components/sheet/sheetLinks'
 import { getSheetPageTitle, getSheetTitleLabel } from '@/components/song/sheetDisplay'
 import { SongPage } from '@/pages/SongPage'
+import { buildChartOgImageAlt, buildChartOgImageUrl } from '../../../-chart-og-meta'
 
 export const Route = createFileRoute('/songs/$songId/$type/$difficulty')({
   ssr: true,
@@ -31,7 +32,18 @@ export const Route = createFileRoute('/songs/$songId/$type/$difficulty')({
     const sheetLabel = getSheetTitleLabel(sheet)
     const pageTitle = getSheetPageTitle(song, sheet)
     const description = `${song.title} by ${song.artist} - ${sheetLabel} chart details, internal levels, and note counts on DXRating.`
-    const image = `https://shama.dxrating.net/images/cover/v2/${song.imageName}.jpg`
+    const coverImage = `https://shama.dxrating.net/images/cover/v2/${song.imageName}.jpg`
+    const image = buildChartOgImageUrl({
+      songId: song.songId,
+      type: sheet.type,
+      difficulty: sheet.difficulty,
+    })
+    const imageAlt = buildChartOgImageAlt({
+      title: song.title,
+      artist: song.artist,
+      type: sheet.type,
+      difficulty: sheet.difficulty,
+    })
     const url = buildSheetLink(
       {
         songId: song.songId,
@@ -47,12 +59,18 @@ export const Route = createFileRoute('/songs/$songId/$type/$difficulty')({
         { property: 'og:title', content: pageTitle },
         { property: 'og:description', content: description },
         { property: 'og:image', content: image },
+        { property: 'og:image:secure_url', content: image },
+        { property: 'og:image:type', content: 'image/png' },
+        { property: 'og:image:width', content: '1200' },
+        { property: 'og:image:height', content: '630' },
+        { property: 'og:image:alt', content: imageAlt },
         { property: 'og:url', content: url },
         { property: 'og:type', content: 'website' },
         { name: 'twitter:card', content: 'summary_large_image' },
         { name: 'twitter:title', content: pageTitle },
         { name: 'twitter:description', content: description },
         { name: 'twitter:image', content: image },
+        { name: 'twitter:image:alt', content: imageAlt },
       ],
       links: [{ rel: 'canonical', href: url }],
       scripts: [
@@ -66,7 +84,7 @@ export const Route = createFileRoute('/songs/$songId/$type/$difficulty')({
               '@type': 'Person',
               name: song.artist,
             },
-            image,
+            image: coverImage,
             url,
             genre: song.category,
             isPartOf: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,9 @@ importers:
       '@simplewebauthn/server':
         specifier: ^13.3.0
         version: 13.3.0
+      '@takumi-rs/image-response':
+        specifier: 1.1.2
+        version: 1.1.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.14
@@ -3668,6 +3671,79 @@ packages:
     peerDependencies:
       '@svgr/core': '*'
 
+  '@takumi-rs/core-darwin-arm64@1.1.2':
+    resolution: {integrity: sha512-CLPzikYAND2xFm0Lg5HKImCOnl+Sue4F/WIcm1Z2ykL7h2r9rWDBzcFqGhAEFj9onMJH6c60Mph8kDa1jdj2rQ==}
+    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@takumi-rs/core-darwin-x64@1.1.2':
+    resolution: {integrity: sha512-eH351x+BJOMdLQgUoVKEIfTQbBjR6Dv7rzTLZUdWwbbwjEe38geCNsxQunHQ96nsB7M+0sGc8aJjOkd+0qoK3g==}
+    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@takumi-rs/core-linux-arm64-gnu@1.1.2':
+    resolution: {integrity: sha512-2cuSnKWAfQjQwS+7aprz0LRkztPVsGqWGTto0TydVI81z7sNyC4kZWoJMTpkNb3439HB03UBStQVacgUeVOL+w==}
+    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@takumi-rs/core-linux-arm64-musl@1.1.2':
+    resolution: {integrity: sha512-7OIdvVy6lbr49LIBe96uvlOg4Awmye5w+DgL4d0rRi1Zv7bmY23ciBCGaM+7jjkZgcThGrlZKz1Ecopx56pPqA==}
+    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@takumi-rs/core-linux-x64-gnu@1.1.2':
+    resolution: {integrity: sha512-IXEhQjGSGye+kwawDad00kN2cLpj1rPF5u0K4KsANvWxa/dho32Nnw+RX8cCtPGiuvEKhtENxtdc7pVSx1E84g==}
+    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@takumi-rs/core-linux-x64-musl@1.1.2':
+    resolution: {integrity: sha512-Q2vuZCwQ/XmHwwbJxSKNNEKdWdhsvBMhTF8pyyGti5s44yx7W6+a0MkDdMRAkStzDhH6HeZlpknpHcUk4R4g8w==}
+    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@takumi-rs/core-win32-arm64-msvc@1.1.2':
+    resolution: {integrity: sha512-CKpslxYCltih/lL+h7xkVzsfIZtDcXp3WGk01fudgx82Ic87b/jjRMX5KE4f/exkgrKxshRF4yCQGGeQ3vIhiw==}
+    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@takumi-rs/core-win32-x64-msvc@1.1.2':
+    resolution: {integrity: sha512-c+n2vPpDscMuTHZ29eJp8did5tlJ/KKBKicc51D6AdkA5jhr7MLeryzIKe3ob59iQttWYd/1j4+tUwoO6yEusg==}
+    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@takumi-rs/core@1.1.2':
+    resolution: {integrity: sha512-JI0kUis5MCPzOt2sCahBZLVJERpp1t1fXTRBaBbCGploUa/hqRA9HW6Nr+tccDM/C6wy9FDrJnI4SB56W0HfDA==}
+    engines: {node: '>= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0'}
+
+  '@takumi-rs/helpers@1.1.2':
+    resolution: {integrity: sha512-Edvmk7UzPhlbUCYpIqeBBfq9h/lAeWAhtwIhJJ10vxv7qNWjgfIPakzNWeAYhFVj8KT5y47S3RLT3cKVniqI5g==}
+    peerDependencies:
+      react: ^19.2.5
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  '@takumi-rs/image-response@1.1.2':
+    resolution: {integrity: sha512-kXkGzHdFBAXH/05KEFkgVP2oJScTeWD7nORQzEiBajYthRyU44ZBctZzEBobvWfagDhfeS86sD+OZB1AjSE1KA==}
+
+  '@takumi-rs/wasm@1.1.2':
+    resolution: {integrity: sha512-in2kLgFp6nuXie5q7blvRk8m/3UuvNDtc5SEFUh6Eu2yn20PcElj1VMdXhQhn+IN0h119BUWWdJ3AuEuh8PiDg==}
+
   '@tanstack/history@1.161.6':
     resolution: {integrity: sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg==}
     engines: {node: '>=20.19'}
@@ -6767,6 +6843,9 @@ packages:
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
+
+  takumi-js@1.1.2:
+    resolution: {integrity: sha512-S8Ff0zBUQJ8VC40r7y1RPBo5QXFXV3U868M+T8B8JGt5Tko8l83DVEr1BYLOxqUenEeev853S708oE0aD50eZA==}
 
   throttle-debounce@3.0.1:
     resolution: {integrity: sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==}
@@ -10123,6 +10202,65 @@ snapshots:
       svg-parser: 2.0.4
     transitivePeerDependencies:
       - supports-color
+
+  '@takumi-rs/core-darwin-arm64@1.1.2':
+    optional: true
+
+  '@takumi-rs/core-darwin-x64@1.1.2':
+    optional: true
+
+  '@takumi-rs/core-linux-arm64-gnu@1.1.2':
+    optional: true
+
+  '@takumi-rs/core-linux-arm64-musl@1.1.2':
+    optional: true
+
+  '@takumi-rs/core-linux-x64-gnu@1.1.2':
+    optional: true
+
+  '@takumi-rs/core-linux-x64-musl@1.1.2':
+    optional: true
+
+  '@takumi-rs/core-win32-arm64-msvc@1.1.2':
+    optional: true
+
+  '@takumi-rs/core-win32-x64-msvc@1.1.2':
+    optional: true
+
+  '@takumi-rs/core@1.1.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@takumi-rs/helpers': 1.1.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+    optionalDependencies:
+      '@takumi-rs/core-darwin-arm64': 1.1.2
+      '@takumi-rs/core-darwin-x64': 1.1.2
+      '@takumi-rs/core-linux-arm64-gnu': 1.1.2
+      '@takumi-rs/core-linux-arm64-musl': 1.1.2
+      '@takumi-rs/core-linux-x64-gnu': 1.1.2
+      '@takumi-rs/core-linux-x64-musl': 1.1.2
+      '@takumi-rs/core-win32-arm64-msvc': 1.1.2
+      '@takumi-rs/core-win32-x64-msvc': 1.1.2
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@takumi-rs/helpers@1.1.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@takumi-rs/image-response@1.1.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      takumi-js: 1.1.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@takumi-rs/wasm@1.1.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@takumi-rs/helpers': 1.1.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+    transitivePeerDependencies:
+      - react
+      - react-dom
 
   '@tanstack/history@1.161.6': {}
 
@@ -13585,6 +13723,15 @@ snapshots:
       use-sync-external-store: 1.6.0(react@19.2.4)
 
   tagged-tag@1.0.0: {}
+
+  takumi-js@1.1.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@takumi-rs/core': 1.1.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@takumi-rs/helpers': 1.1.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@takumi-rs/wasm': 1.1.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+    transitivePeerDependencies:
+      - react
+      - react-dom
 
   throttle-debounce@3.0.1: {}
 


### PR DESCRIPTION
## Summary

Adds a backend Takumi-based Open Graph image renderer for song chart pages and wires song route metadata to use the generated image.

## Changes

- Adds `/functions/render-chart-og/v0/:songId/:type/:difficulty` for rendering a 1200x630 PNG chart preview.
- Designs the OG image with cover art, category, title, artist, DX type artwork, merged difficulty/internal-level pill, chart metadata, and note counts.
- Adds dynamic title sizing for long song names, including the longest current `dxdata` title.
- Adds web helpers for canonical OG image URLs and alt text, and updates chart route meta tags.
- Adds focused backend and web tests.

## Validation

- `pnpm format:check`
- `pnpm --dir apps/backend exec vitest run src/test/chart-og-image.test.ts`
- `pnpm --dir apps/web exec vitest run 'src/routes/__tests__/-chart-og-meta.test.ts'`
- `pnpm --filter @gekichumai/backend build`
- `pnpm --filter @gekichumai/backend build:bundle`
- `pnpm --filter @gekichumai/dxrating-web build`

Note: the web build emits local Sentry auth-token warnings, but exits successfully.