### PR TITLE
Allow Galvin Workers preview origins in API CORS

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -53,8 +53,12 @@ app.use(
         return origin
       }
 
-      // Allow production domain and Cloudflare Pages previews
-      if (origin === 'https://dxrating.net' || origin.endsWith('.dxrating.pages.dev')) {
+      // Allow production domain and preview deployments
+      if (
+        origin === 'https://dxrating.net' ||
+        origin.endsWith('.dxrating.pages.dev') ||
+        origin.endsWith('.galvin.workers.dev')
+      ) {
         return origin
       }
 

--- a/apps/backend/src/test/cors.test.ts
+++ b/apps/backend/src/test/cors.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { app } from '../app.js'
+
+describe('CORS', () => {
+  it('allows Galvin Workers preview origins', async () => {
+    const origin = 'https://dxrating-preview.galvin.workers.dev'
+
+    const response = await app.request('/health', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: origin,
+        'Access-Control-Request-Method': 'GET',
+      },
+    })
+
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe(origin)
+    expect(response.headers.get('Access-Control-Allow-Credentials')).toBe('true')
+  })
+})


### PR DESCRIPTION
## Summary
- Allow `*.galvin.workers.dev` origins through the backend CORS allowlist
- Add a regression test covering an `OPTIONS` preflight from a Galvin Workers preview origin

## Testing
- `pnpm --filter @gekichumai/backend exec vitest run src/test/cors.test.ts`
- `pnpm format:check`
- `pnpm --filter @gekichumai/backend lint`
- `pnpm --filter @gekichumai/backend build`