### PR TITLE
Move chart OG image rendering to the oRPC API route

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -5,7 +5,6 @@ import { createMiddleware } from 'hono/factory'
 import { cors } from 'hono/cors'
 import { z } from 'zod'
 import { auth } from './auth.js'
-import { handler as chartOgImageRenderer } from './services/functions/chart-og-image/index.js'
 import { handler as oneshotRenderer } from './services/functions/oneshot-renderer/index.js'
 import {
   v0Handler as fetchNetRecordsV0Handler,
@@ -173,7 +172,6 @@ app.post('/api/v1/monitoring/tunnel', async (c) => {
 app.post('/functions/fetch-net-records/v0', verifyParams, fetchNetRecordsV0Handler)
 app.post('/functions/fetch-net-records/v1/:region', verifyParams, fetchNetRecordsV1Handler)
 app.post('/functions/render-oneshot/v0', oneshotRenderer)
-app.get('/functions/render-chart-og/v0/:songId/:type/:difficulty', chartOgImageRenderer)
 
 // LXNS OAuth callback (direct Hono route — must be before oRPC catch-all since it redirects)
 app.get('/api/v1/io/import/lxns/oauth_callback', async (c) => {

--- a/apps/backend/src/contract.ts
+++ b/apps/backend/src/contract.ts
@@ -123,6 +123,17 @@ export const TrendingResponseSchema = z.object({
   dateTo: z.string(),
 })
 
+const ChartOgImageInputSchema = z.object({
+  songId: z.string(),
+  type: z.string(),
+  difficulty: z.string(),
+})
+
+const ChartOgImageOutputSchema = z.object({
+  headers: z.record(z.string(), z.string()),
+  body: z.instanceof(Blob),
+})
+
 export const appContract = oc.router({
   tags: {
     list: oc
@@ -224,6 +235,18 @@ export const appContract = oc.router({
         spec: (spec) => ({ ...spec, security: [] }),
       })
       .output(TrendingResponseSchema),
+  },
+  chartOgImage: {
+    render: oc
+      .route({
+        method: 'GET',
+        path: '/songs/{songId}/{type}/{difficulty}/og-image',
+        summary: 'Render chart OpenGraph image',
+        tags: ['internal'],
+        outputStructure: 'detailed',
+      })
+      .input(ChartOgImageInputSchema)
+      .output(ChartOgImageOutputSchema),
   },
   lxns: {
     authorize: oc

--- a/apps/backend/src/router.ts
+++ b/apps/backend/src/router.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/node'
-import { implement } from '@orpc/server'
+import { ORPCError, implement } from '@orpc/server'
 import { appContract } from './contract.js'
 import { db } from './db/index.js'
 import { tags, tagGroups, tagSongs, comments, profiles, songAliases } from './db/schema.js'
@@ -7,6 +7,7 @@ import { eq, and, desc } from 'drizzle-orm'
 import Keyv from 'keyv'
 import type { auth } from './auth.js'
 import { config } from './config.js'
+import { renderChartOgImageOutput } from './services/functions/chart-og-image/index.js'
 
 type Context = {
   user?: typeof auth.$Infer.Session.user
@@ -251,6 +252,17 @@ const analyticsHandler = {
   }),
 }
 
+const chartOgImageHandler = {
+  render: os.chartOgImage.render.handler(async ({ input }) => {
+    const output = await renderChartOgImageOutput(input)
+    if (!output) {
+      throw new ORPCError('NOT_FOUND', { message: 'Chart not found' })
+    }
+
+    return output
+  }),
+}
+
 const maimaiHandler = {
   fetchRecords: os.maimai.fetchRecords.handler(async ({ input }) => {
     const { id, password, region } = input
@@ -313,6 +325,7 @@ export const appRouter = os.router({
   comments: commentsHandler,
   aliases: aliasesHandler,
   analytics: analyticsHandler,
+  chartOgImage: chartOgImageHandler,
   maimai: maimaiHandler,
   lxns: lxnsHandler,
 })

--- a/apps/backend/src/services/functions/chart-og-image/index.tsx
+++ b/apps/backend/src/services/functions/chart-og-image/index.tsx
@@ -2,6 +2,7 @@ import { DifficultyEnum, TypeEnum, dxdata } from '@gekichumai/dxdata'
 import type { NoteCounts } from '@gekichumai/dxdata'
 import { ImageResponse } from '@takumi-rs/image-response'
 import type { Handler } from 'hono'
+import { createHash } from 'node:crypto'
 import type { CSSProperties, ReactNode } from 'react'
 import { fetchAsset, fetchImageAsset } from '../oneshot-renderer/assetFetcher.js'
 
@@ -10,7 +11,9 @@ export const CHART_OG_IMAGE_HEIGHT = 630
 const ASSET_ORIGIN = 'https://shama.dxrating.net'
 const FRONTEND_ORIGIN = 'https://dxrating.net'
 
-const CACHE_CONTROL = 'public, max-age=86400, s-maxage=604800, stale-while-revalidate=604800'
+export const CHART_OG_IMAGE_CACHE_CONTROL = 'public, max-age=86400, s-maxage=604800, stale-while-revalidate=604800'
+const CHART_OG_IMAGE_CONTENT_TYPE = 'image/png'
+const CHART_OG_IMAGE_CONTENT_DISPOSITION = 'inline; filename="chart-og.png"; filename*=utf-8\'\'chart-og.png'
 
 type DifficultyDisplay = {
   title: string
@@ -56,6 +59,11 @@ export type ChartOgImageData = {
 }
 
 export type RenderChartOgImage = (data: ChartOgImageData) => Promise<ArrayBuffer | Uint8Array>
+
+export type ChartOgImageOutput = {
+  headers: Record<string, string>
+  body: Blob
+}
 
 export function buildChartOgDetailUrl(songId: string, type: string, difficulty: string) {
   return `${FRONTEND_ORIGIN}/songs/${encodeURIComponent(songId)}/${encodeURIComponent(type)}/${encodeURIComponent(difficulty)}`
@@ -110,19 +118,42 @@ export function createChartOgImageHandler(renderImage: RenderChartOgImage = rend
     const difficulty = c.req.param('difficulty')
     if (!songId || !type || !difficulty) return c.text('Chart not found', 404)
 
-    const data = resolveChartOgImageData(songId, type, difficulty)
-    if (!data) return c.text('Chart not found', 404)
+    const output = await renderChartOgImageOutput({ songId, type, difficulty }, renderImage)
+    if (!output) return c.text('Chart not found', 404)
 
-    const image = await renderImage(data)
-    const body = toArrayBuffer(image)
-    return new Response(body, {
+    return new Response(output.body, {
       headers: {
-        'Cache-Control': CACHE_CONTROL,
-        'Content-Length': String(image.byteLength),
-        'Content-Type': 'image/png',
+        ...output.headers,
+        'Content-Length': String(output.body.size),
       },
     })
   }
+}
+
+export async function renderChartOgImageOutput(
+  input: { songId: string; type: string; difficulty: string },
+  renderImage: RenderChartOgImage = renderChartOgImage,
+): Promise<ChartOgImageOutput | null> {
+  const data = resolveChartOgImageData(input.songId, input.type, input.difficulty)
+  if (!data) return null
+
+  const image = await renderImage(data)
+  const body = toArrayBuffer(image)
+
+  return {
+    headers: {
+      'Cache-Control': CHART_OG_IMAGE_CACHE_CONTROL,
+      'Content-Disposition': CHART_OG_IMAGE_CONTENT_DISPOSITION,
+      'Content-Type': CHART_OG_IMAGE_CONTENT_TYPE,
+      ETag: createChartOgImageEtag(body),
+      'X-Content-Type-Options': 'nosniff',
+    },
+    body: new Blob([body], { type: CHART_OG_IMAGE_CONTENT_TYPE }),
+  }
+}
+
+function createChartOgImageEtag(image: ArrayBuffer) {
+  return `"sha256-${createHash('sha256').update(Buffer.from(image)).digest('hex')}"`
 }
 
 function toArrayBuffer(image: ArrayBuffer | Uint8Array): ArrayBuffer {

--- a/apps/backend/src/test/chart-og-image.test.ts
+++ b/apps/backend/src/test/chart-og-image.test.ts
@@ -1,6 +1,7 @@
 import { DifficultyEnum, TypeEnum, dxdata } from '@gekichumai/dxdata'
 import { Hono } from 'hono'
 import { describe, expect, it, vi } from 'vitest'
+import { app } from '../app.js'
 import {
   createChartOgImageHandler,
   formatInternalLevelLabelParts,
@@ -20,6 +21,29 @@ const sheet = song.sheets.find(
 if (!sheet) throw new Error('Expected fixture song to include selected sheet')
 
 describe('chart OG image handler', () => {
+  it('serves chart images from the API v1 endpoint format', async () => {
+    const res = await app.request(
+      `/api/v1/songs/${encodeURIComponent(song.songId)}/${sheet.type}/${sheet.difficulty}/og-image`,
+    )
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('image/png')
+    expect(res.headers.get('cache-control')).toContain('public')
+    expect(res.headers.get('content-disposition')).toBe(
+      'inline; filename="chart-og.png"; filename*=utf-8\'\'chart-og.png',
+    )
+    expect(res.headers.get('etag')).toMatch(/^"sha256-[a-f0-9]{64}"$/)
+    expect(res.headers.get('x-content-type-options')).toBe('nosniff')
+    expect((await res.arrayBuffer()).byteLength).toBeGreaterThan(0)
+  })
+
+  it('keeps the internal chart image endpoint out of the OpenAPI spec', async () => {
+    const res = await app.request('/spec.json')
+    const spec = await res.json()
+
+    expect(spec.paths).not.toHaveProperty('/songs/{songId}/{type}/{difficulty}/og-image')
+  })
+
   it('resolves chart data and returns a cacheable PNG response', async () => {
     const image = new Uint8Array([137, 80, 78, 71])
     const renderImage = vi.fn(async () => image)
@@ -31,6 +55,11 @@ describe('chart OG image handler', () => {
     expect(res.status).toBe(200)
     expect(res.headers.get('content-type')).toBe('image/png')
     expect(res.headers.get('cache-control')).toContain('public')
+    expect(res.headers.get('content-disposition')).toBe(
+      'inline; filename="chart-og.png"; filename*=utf-8\'\'chart-og.png',
+    )
+    expect(res.headers.get('etag')).toBe('"sha256-0f4636c78f65d3639ece5a064b5ae753e3408614a14fb18ab4d7540d2c248543"')
+    expect(res.headers.get('x-content-type-options')).toBe('nosniff')
     expect(await res.arrayBuffer()).toEqual(image.buffer)
     expect(renderImage).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/web/src/routes/-chart-og-meta.ts
+++ b/apps/web/src/routes/-chart-og-meta.ts
@@ -12,7 +12,7 @@ export function buildChartOgImageUrl({
   type: TypeEnum | string
   difficulty: DifficultyEnum | string
 }) {
-  return `${CHART_OG_IMAGE_ORIGIN}/functions/render-chart-og/v0/${encodeURIComponent(songId)}/${encodeURIComponent(type)}/${encodeURIComponent(difficulty)}`
+  return `${CHART_OG_IMAGE_ORIGIN}/api/v1/songs/${encodeURIComponent(songId)}/${encodeURIComponent(type)}/${encodeURIComponent(difficulty)}/og-image`
 }
 
 export function buildChartOgImageAlt({

--- a/apps/web/src/routes/__tests__/-chart-og-meta.test.ts
+++ b/apps/web/src/routes/__tests__/-chart-og-meta.test.ts
@@ -11,7 +11,7 @@ describe('chart OG metadata helpers', () => {
         difficulty: DifficultyEnum.Master,
       }),
     ).toBe(
-      'https://miruku.dxrating.net/functions/render-chart-og/v0/1%2F3%E3%81%AE%E7%B4%94%E6%83%85%E3%81%AA%E6%84%9F%E6%83%85%20%26%20%3Ctest%3E/dx/master',
+      'https://miruku.dxrating.net/api/v1/songs/1%2F3%E3%81%AE%E7%B4%94%E6%83%85%E3%81%AA%E6%84%9F%E6%83%85%20%26%20%3Ctest%3E/dx/master/og-image',
     )
   })
 


### PR DESCRIPTION
## Summary
- Moved chart OG image rendering from the standalone function route to the oRPC OpenAPI route at `/api/v1/songs/{songId}/{type}/{difficulty}/og-image`
- Kept the route out of Scalar docs by marking it internal
- Updated the web OG image URL builder to point at the new endpoint
- Added response metadata for PNG delivery, including cache headers, content disposition, nosniff, and a SHA-256 ETag

## Testing
- Added backend coverage for the new API route, hidden OpenAPI visibility, and response headers
- Updated the web metadata test for the new image URL format
- Verified backend build, web build, formatting, and linting