### PR TITLE
Use ts-pattern for redundant ternary branches

### DIFF
--- a/apps/backend/src/services/functions/oneshot-renderer/index.tsx
+++ b/apps/backend/src/services/functions/oneshot-renderer/index.tsx
@@ -12,6 +12,7 @@ import { renderAsync } from '@resvg/resvg-js'
 import type { Context } from 'hono'
 import satori, { type Font } from 'satori'
 import sharp from 'sharp'
+import { match } from 'ts-pattern'
 import { z } from 'zod'
 import { type Scope, Sentry } from '../../../lib/functions/sentry.js'
 import { fetchAsset } from './assetFetcher.js'
@@ -284,7 +285,10 @@ export const calculateEntries = (
           },
         ],
       })
-      const bucket = best50.b15.length ? 'b15' : best50.b35.length ? 'b35' : null
+      const bucket = match({ hasB15: best50.b15.length > 0, hasB35: best50.b35.length > 0 })
+        .with({ hasB15: true }, () => 'b15' as const)
+        .with({ hasB35: true }, () => 'b35' as const)
+        .otherwise(() => null)
       return bucket ? [{ bucket, index, renderData }] : []
     }),
   )

--- a/apps/web/src/components/rating/io/import/ImportFromNETRecordsListItem.tsx
+++ b/apps/web/src/components/rating/io/import/ImportFromNETRecordsListItem.tsx
@@ -23,6 +23,7 @@ import { type FC, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useLocalStorage } from 'react-use'
 import type { ListActions } from 'react-use/lib/useList'
+import { match } from 'ts-pattern'
 import IconMdiConnection from '~icons/mdi/connection'
 import { useAppContextDXDataVersion } from '../../../../models/context/useAppContext'
 import type { PlayEntry } from '../../RatingCalculatorAddEntryForm'
@@ -114,7 +115,10 @@ const ImportFromNETRecordsDialogContent: FC<{
   const [autoImport, setAutoImport] = useLocalStorage<AutoImportMode>('rating-auto-import-from-net', false)
   const [busy, setBusy] = useState(false)
   const [progress, setProgress] = useState<ImportFromNETRecordsProgress | null>(null)
-  const mappedAutoImport = autoImport === true ? 'replace' : (autoImport as unknown) === 'false' ? false : autoImport // Legacy support
+  const mappedAutoImport = match(autoImport as AutoImportMode | 'false')
+    .with(true, () => 'replace' as const)
+    .with('false', () => false as const)
+    .otherwise((value) => value)
   const appVersion = useAppContextDXDataVersion()
 
   useEffect(() => {

--- a/apps/web/src/pages/LxnsOauthCallback.tsx
+++ b/apps/web/src/pages/LxnsOauthCallback.tsx
@@ -3,6 +3,7 @@ import { Button, CircularProgress } from '@mui/material'
 import { type FC, useEffect, useState } from 'react'
 import toast from 'react-hot-toast'
 import { useTranslation } from 'react-i18next'
+import { match } from 'ts-pattern'
 import IconCheck from '~icons/material-symbols/check-circle-outline'
 import IconError from '~icons/material-symbols/error-outline'
 
@@ -10,8 +11,10 @@ export const LxnsOauthCallback: FC = () => {
   const { t } = useTranslation(['rating-calculator'])
   const navigate = useNavigate()
   const params = new URLSearchParams(window.location.search)
-  const initialStatus =
-    params.get('status') === 'success' ? 'success' : params.get('status') === 'error' ? 'error' : 'loading'
+  const initialStatus = match(params.get('status'))
+    .with('success', () => 'success' as const)
+    .with('error', () => 'error' as const)
+    .otherwise(() => 'loading' as const)
   const initialError = params.get('error') || 'unknown'
 
   const [status] = useState<'loading' | 'success' | 'error'>(initialStatus)

--- a/packages/maimai-domain/package.json
+++ b/packages/maimai-domain/package.json
@@ -10,7 +10,8 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
-    "@gekichumai/dxdata": "workspace:*"
+    "@gekichumai/dxdata": "workspace:*",
+    "ts-pattern": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/packages/maimai-domain/src/best50.ts
+++ b/packages/maimai-domain/src/best50.ts
@@ -1,4 +1,5 @@
 import { VERSION_ID_MAP, VersionEnum, type VersionEnum as Version } from '@gekichumai/dxdata'
+import { match } from 'ts-pattern'
 import type { SongCatalog } from './song-catalog.js'
 import type { Best50Bucket, ComboFlag, RatingEntry, Region, VersionedSheet } from './types.js'
 
@@ -155,11 +156,7 @@ export function calculateBest50({
       entry: entry.entry,
       sheet: entry.sheet,
       rating: entry.rating,
-      bucket: b15Ids.has(entry.entry.sheetId)
-        ? ('b15' as const)
-        : b35Ids.has(entry.entry.sheetId)
-          ? ('b35' as const)
-          : null,
+      bucket: getSelectedBucket(b15Ids.has(entry.entry.sheetId), b35Ids.has(entry.entry.sheetId)),
     }),
   )
   const b15 = allEntries.filter((entry) => entry.bucket === 'b15').sort(byRatingDesc)
@@ -180,6 +177,13 @@ function getEntryBucket(
   if (isB15Sheet(entry.sheet.version, appVersion, region)) return 'b15'
   if (isB35Sheet(entry.sheet.version, appVersion, region)) return 'b35'
   return null
+}
+
+function getSelectedBucket(inB15: boolean, inB35: boolean): Best50Bucket | null {
+  return match({ inB15, inB35 })
+    .with({ inB15: true }, () => 'b15' as const)
+    .with({ inB35: true }, () => 'b35' as const)
+    .otherwise(() => null)
 }
 
 function getAuthoritativeBest50Hint(

--- a/packages/maimai-domain/src/import-normalizers.ts
+++ b/packages/maimai-domain/src/import-normalizers.ts
@@ -1,4 +1,5 @@
 import { DifficultyEnum, TypeEnum } from '@gekichumai/dxdata'
+import { match } from 'ts-pattern'
 import type { SongCatalog } from './song-catalog.js'
 import type {
   Best50Bucket,
@@ -86,7 +87,7 @@ export function normalizeLxnsScores(catalog: SongCatalog, rows: LxnsScoreRow[]):
       const difficulty = LEVEL_INDEX_TO_DIFFICULTY[row.levelIndex]
       if (!difficulty) return missing('lxns', row, 'invalid-difficulty', `Unknown LXNS level index: ${row.levelIndex}`)
 
-      const type = row.type === 'standard' ? TypeEnum.STD : row.type === 'dx' ? TypeEnum.DX : null
+      const type = normalizeStandardDxType(row.type)
       if (!type) return missing('lxns', row, 'invalid-type', `Unknown LXNS chart type: ${row.type}`)
 
       const achievement = validateAchievement('lxns', row, row.achievements, 1)
@@ -119,7 +120,7 @@ export interface MaimaiNetRecordRow {
 export function normalizeMaimaiNetRecords(catalog: SongCatalog, rows: MaimaiNetRecordRow[]): RatingImportResult {
   return finalizeImport(
     rows.map((row) => {
-      const type = row.sheet.type === 'standard' ? TypeEnum.STD : row.sheet.type === 'dx' ? TypeEnum.DX : null
+      const type = normalizeStandardDxType(row.sheet.type)
       const difficulty = Object.values(DifficultyEnum).includes(row.sheet.difficulty as DifficultyEnum)
         ? (row.sheet.difficulty as DifficultyEnum)
         : null
@@ -170,7 +171,7 @@ export function normalizeDivingFishRows(catalog: SongCatalog, rows: DivingFishRo
   return finalizeImport(
     rows.map((row) => {
       const difficulty = LEVEL_INDEX_TO_DIFFICULTY[row.level_index]
-      const type = row.type.toLowerCase() === 'sd' ? TypeEnum.STD : row.type.toLowerCase() === 'dx' ? TypeEnum.DX : null
+      const type = normalizeDivingFishType(row.type)
       if (!difficulty) {
         return missing('diving-fish', row, 'invalid-difficulty', `Unknown Diving Fish level index: ${row.level_index}`)
       }
@@ -442,6 +443,22 @@ function normalizeAquaComboStatus(value: number | string | null): ComboFlag {
 function normalizeAquaSyncStatus(value: number | string | null): SyncFlag {
   if (typeof value === 'number') return AQUA_SYNC_STATUS_TO_FLAG[value] ?? null
   return normalizeSync(value)
+}
+
+function normalizeStandardDxType(value: string): TypeEnum.STD | TypeEnum.DX | null {
+  return match(value)
+    .returnType<TypeEnum.STD | TypeEnum.DX | null>()
+    .with('standard', () => TypeEnum.STD)
+    .with('dx', () => TypeEnum.DX)
+    .otherwise(() => null)
+}
+
+function normalizeDivingFishType(value: string): TypeEnum.STD | TypeEnum.DX | null {
+  return match(value.toLowerCase())
+    .returnType<TypeEnum.STD | TypeEnum.DX | null>()
+    .with('sd', () => TypeEnum.STD)
+    .with('dx', () => TypeEnum.DX)
+    .otherwise(() => null)
 }
 
 function extractNetCombo(flags: string[]): ComboFlag {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -488,6 +488,9 @@ importers:
       '@gekichumai/dxdata':
         specifier: workspace:*
         version: link:../dxdata
+      ts-pattern:
+        specifier: 'catalog:'
+        version: 5.9.0
     devDependencies:
       '@types/node':
         specifier: 'catalog:'


### PR DESCRIPTION
## Summary
- Replaced a handful of redundant nested ternaries with `ts-pattern` matches in shared maimai-domain logic and a few app-level branches.
- Added `ts-pattern` to `@gekichumai/maimai-domain` so the package can use the matcher directly.
- Kept the changes scoped to the existing conditional paths without changing behavior.

## Testing
- `pnpm --filter @gekichumai/maimai-domain test`
- `pnpm --filter @gekichumai/maimai-domain build`
- `pnpm --filter @gekichumai/backend build`
- `pnpm --filter @gekichumai/dxrating-web build`
- `pnpm format:check`
- `pnpm lint`