### PR TITLE
Improve AI search visibility

### DIFF
--- a/apps/web/src/pages/SongPage.tsx
+++ b/apps/web/src/pages/SongPage.tsx
@@ -13,6 +13,7 @@ import { SongHeader } from '../components/song/SongHeader'
 import { SongSheetContent } from '../components/song/SongSheetContent'
 import { SongSheetTabs } from '../components/song/SongSheetTabs'
 import { getSheetPageTitle } from '../components/song/sheetDisplay'
+import { getVisibleSongPageSheets } from './songPageSheets'
 
 const routeApi = getRouteApi('/songs/$songId/$type/$difficulty')
 
@@ -70,6 +71,7 @@ export const SongPage: FC = () => {
     (sheet) => sheet.type === activeType && sheet.difficulty === activeDifficulty,
   )
   const headerSheet = activeSheet ?? flattenedSheets[0]
+  const visibleSheets = getVisibleSongPageSheets(flattenedSheets, activeType, activeDifficulty)
   const locale = toSupportedLocale(i18n.language) ?? DEFAULT_LOCALE
   const pageTitle = song && activeSheet ? getSheetPageTitle(song, activeSheet, locale) : undefined
 
@@ -137,14 +139,11 @@ export const SongPage: FC = () => {
         onDifficultyChange={handleDifficultyChange}
       />
 
-      {flattenedSheets.map((sheet) => {
-        const isActive = sheet.type === activeType && sheet.difficulty === activeDifficulty
-        return (
-          <div key={sheet.id} style={isActive ? undefined : { display: 'none' }} aria-hidden={!isActive}>
-            <SongSheetContent sheet={sheet} isActive={isActive} />
-          </div>
-        )
-      })}
+      {visibleSheets.map((sheet) => (
+        <div key={sheet.id}>
+          <SongSheetContent sheet={sheet} isActive />
+        </div>
+      ))}
     </div>
   )
 }

--- a/apps/web/src/pages/SongPage.tsx
+++ b/apps/web/src/pages/SongPage.tsx
@@ -7,18 +7,16 @@ import MdiArrowLeft from '~icons/mdi/arrow-left'
 import { TYPE_ORDER, getHighestDifficulty } from '../models/constants'
 import { useAppContextDXDataVersion } from '../models/context/useAppContext'
 import { useServerAliases } from '../models/useServerAliases'
-import { DEFAULT_LOCALE, toSupportedLocale } from '../setup/locale'
 import { type FlattenedSheet, canonicalId, getSearchAcronymsWithServerAliases } from '../songs'
 import { SongHeader } from '../components/song/SongHeader'
 import { SongSheetContent } from '../components/song/SongSheetContent'
 import { SongSheetTabs } from '../components/song/SongSheetTabs'
-import { getSheetPageTitle } from '../components/song/sheetDisplay'
 import { getVisibleSongPageSheets } from './songPageSheets'
 
 const routeApi = getRouteApi('/songs/$songId/$type/$difficulty')
 
 export const SongPage: FC = () => {
-  const { t, i18n } = useTranslation(['song'])
+  const { t } = useTranslation(['song'])
   const { songId, type, difficulty } = routeApi.useParams()
   const navigate = useNavigate()
   const appVersion = useAppContextDXDataVersion()
@@ -72,8 +70,6 @@ export const SongPage: FC = () => {
   )
   const headerSheet = activeSheet ?? flattenedSheets[0]
   const visibleSheets = getVisibleSongPageSheets(flattenedSheets, activeType, activeDifficulty)
-  const locale = toSupportedLocale(i18n.language) ?? DEFAULT_LOCALE
-  const pageTitle = song && activeSheet ? getSheetPageTitle(song, activeSheet, locale) : undefined
 
   const handleTypeChange = (newType: TypeEnum) => {
     const sheetsOfType = flattenedSheets.filter((s) => s.type === newType)
@@ -112,7 +108,6 @@ export const SongPage: FC = () => {
 
   return (
     <div className="max-w-2xl mx-auto px-4 py-6 flex flex-col gap-4">
-      {pageTitle && <title>{pageTitle}</title>}
       <a
         href="/"
         onClick={(e) => {

--- a/apps/web/src/pages/__tests__/SongPage.test.tsx
+++ b/apps/web/src/pages/__tests__/SongPage.test.tsx
@@ -1,0 +1,61 @@
+import { DifficultyEnum, VersionEnum } from '@gekichumai/dxdata'
+import { render, screen } from '@testing-library/react'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { initI18n } from '@/setup/init-i18n'
+import { SongPage } from '../SongPage'
+
+const routeState = vi.hoisted(() => ({
+  params: {
+    songId: 'WWW',
+    type: 'dx',
+    difficulty: 'basic',
+  },
+  navigate: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  getRouteApi: () => ({
+    useParams: () => routeState.params,
+  }),
+  useNavigate: () => routeState.navigate,
+}))
+
+vi.mock('@/models/context/useAppContext', () => ({
+  useAppContextDXDataVersion: () => VersionEnum.CiRCLEPLUS,
+}))
+
+vi.mock('@/models/useServerAliases', () => ({
+  useServerAliases: () => ({ data: [] }),
+}))
+
+vi.mock('@/components/song/SongHeader', () => ({
+  SongHeader: ({ sheet }: { sheet: { title: string } }) => <h1>{sheet.title}</h1>,
+}))
+
+vi.mock('@/components/song/SongSheetTabs', () => ({
+  SongSheetTabs: () => <nav aria-label="Sheet tabs" />,
+}))
+
+vi.mock('@/components/song/SongSheetContent', () => ({
+  SongSheetContent: ({ sheet }: { sheet: { difficulty: string } }) => (
+    <section data-testid="sheet-content">{sheet.difficulty}</section>
+  ),
+}))
+
+describe('SongPage', () => {
+  beforeAll(() => {
+    initI18n()
+  })
+
+  beforeEach(() => {
+    document.head.innerHTML = '<title>Route-owned title</title>'
+  })
+
+  it('lets route metadata own the document title', () => {
+    render(<SongPage />)
+
+    expect(screen.getByTestId('sheet-content').textContent).toBe(DifficultyEnum.Basic)
+    expect(document.head.querySelectorAll('title')).toHaveLength(1)
+    expect(document.head.querySelector('title')?.textContent).toBe('Route-owned title')
+  })
+})

--- a/apps/web/src/pages/__tests__/songPageSheets.test.ts
+++ b/apps/web/src/pages/__tests__/songPageSheets.test.ts
@@ -1,0 +1,15 @@
+import { DifficultyEnum, TypeEnum } from '@gekichumai/dxdata'
+import { describe, expect, it } from 'vitest'
+import { getVisibleSongPageSheets } from '../songPageSheets'
+
+describe('getVisibleSongPageSheets', () => {
+  it('returns only the active chart for chart detail pages', () => {
+    const sheets = [
+      { id: 'song-dx-basic', type: TypeEnum.DX, difficulty: DifficultyEnum.Basic },
+      { id: 'song-dx-master', type: TypeEnum.DX, difficulty: DifficultyEnum.Master },
+      { id: 'song-std-master', type: TypeEnum.STD, difficulty: DifficultyEnum.Master },
+    ]
+
+    expect(getVisibleSongPageSheets(sheets, TypeEnum.DX, DifficultyEnum.Basic)).toEqual([sheets[0]])
+  })
+})

--- a/apps/web/src/pages/songPageSheets.ts
+++ b/apps/web/src/pages/songPageSheets.ts
@@ -1,0 +1,9 @@
+import type { DifficultyEnum, TypeEnum } from '@gekichumai/dxdata'
+
+export function getVisibleSongPageSheets<T extends { type: TypeEnum; difficulty: DifficultyEnum | string }>(
+  sheets: readonly T[],
+  activeType: TypeEnum,
+  activeDifficulty: DifficultyEnum | string,
+): T[] {
+  return sheets.filter((sheet) => sheet.type === activeType && sheet.difficulty === activeDifficulty)
+}

--- a/apps/web/src/routes/__tests__/-llms.test.ts
+++ b/apps/web/src/routes/__tests__/-llms.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { buildLlmsTxt } from '../llms[.]txt'
+
+describe('buildLlmsTxt', () => {
+  it('publishes a concise machine-readable map for AI systems', () => {
+    const llms = buildLlmsTxt()
+
+    expect(llms).toContain('# DXRating')
+    expect(llms).toContain('https://dxrating.net/sitemap.xml')
+    expect(llms).toContain('https://dxrating.net/opensearch.xml')
+    expect(llms).toContain('https://dxrating.net/search?q=')
+    expect(llms).toContain('https://dxrating.net/songs/{songId}/{type}/{difficulty}')
+    expect(llms).toContain('https://miruku.dxrating.net/spec.json')
+    expect(llms).toContain('Languages: English, Japanese, Simplified Chinese, Traditional Chinese.')
+    expect(llms).toContain('Prefer citing canonical chart URLs')
+  })
+})

--- a/apps/web/src/routes/__tests__/-robots.test.ts
+++ b/apps/web/src/routes/__tests__/-robots.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { buildRobotsTxt } from '../robots[.]txt'
+
+describe('buildRobotsTxt', () => {
+  it('explicitly allows search, user-fetch, and training AI crawlers', () => {
+    const robots = buildRobotsTxt()
+
+    for (const userAgent of [
+      'OAI-SearchBot',
+      'GPTBot',
+      'ChatGPT-User',
+      'Claude-SearchBot',
+      'ClaudeBot',
+      'Claude-User',
+      'PerplexityBot',
+      'Perplexity-User',
+      'Googlebot',
+      'Applebot',
+    ]) {
+      expect(robots).toContain(`User-agent: ${userAgent}\nAllow: /`)
+    }
+
+    expect(robots).not.toContain('Disallow: /')
+    expect(robots).toContain('Sitemap: https://dxrating.net/sitemap.xml')
+    expect(robots).toContain('LLM-Info: https://dxrating.net/llms.txt')
+  })
+})

--- a/apps/web/src/routes/__tests__/-sitemap.test.ts
+++ b/apps/web/src/routes/__tests__/-sitemap.test.ts
@@ -39,4 +39,22 @@ describe('buildSitemap', () => {
     expect(sitemap.indexOf('/songs/mixed/std/master')).toBeLessThan(sitemap.indexOf('/songs/recent/dx/expert'))
     expect(sitemap.indexOf('/songs/recent/dx/expert')).toBeLessThan(sitemap.indexOf('/songs/old/dx/master'))
   })
+
+  it('includes lastmod for chart URLs with release dates', () => {
+    const sitemap = buildSitemap([
+      {
+        songId: 'released',
+        sheets: [{ type: TypeEnum.DX, difficulty: DifficultyEnum.Master, releaseDate: '2026-05-10' }],
+      },
+      {
+        songId: 'undated',
+        sheets: [{ type: TypeEnum.DX, difficulty: DifficultyEnum.Basic }],
+      },
+    ])
+
+    expect(sitemap).toContain('<loc>https://dxrating.net/songs/released/dx/master</loc>')
+    expect(sitemap).toContain('<lastmod>2026-05-10</lastmod>')
+    expect(sitemap).toContain('<loc>https://dxrating.net/songs/undated/dx/basic</loc>')
+    expect(sitemap).not.toContain('<lastmod>undefined</lastmod>')
+  })
 })

--- a/apps/web/src/routes/llms[.]txt.ts
+++ b/apps/web/src/routes/llms[.]txt.ts
@@ -1,0 +1,53 @@
+import { dxdataUpdateTime } from '@gekichumai/dxdata'
+import { createFileRoute } from '@tanstack/react-router'
+
+export function buildLlmsTxt() {
+  return `# DXRating
+
+DXRating is a maimai DX rating calculator and chart database. It provides canonical chart pages, localized metadata, score/rating tools, tags, comments, aliases, and chart facts such as difficulty, internal level, note counts, regions, release dates, and designers.
+
+## Canonical Resources
+
+- Site: https://dxrating.net/
+- Song and chart search: https://dxrating.net/search?q=
+- Rating calculator: https://dxrating.net/rating
+- Sitemap: https://dxrating.net/sitemap.xml
+- OpenSearch description: https://dxrating.net/opensearch.xml
+- API specification: https://miruku.dxrating.net/spec.json
+
+## URL Patterns
+
+- Canonical chart page: https://dxrating.net/songs/{songId}/{type}/{difficulty}
+- Chart types: dx, std, utage, utage2p
+- Difficulties: basic, advanced, expert, master, remaster
+- Chart Open Graph image: https://miruku.dxrating.net/api/v1/songs/{songId}/{type}/{difficulty}/og-image
+
+## Languages
+
+Languages: English, Japanese, Simplified Chinese, Traditional Chinese.
+
+## Data Notes
+
+- Song and chart metadata is generated from the repository's dxdata package.
+- Data update time: ${dxdataUpdateTime}
+- User-generated community data may include tags, comments, and aliases.
+
+## Citation Guidance
+
+Prefer citing canonical chart URLs when answering chart-specific questions. Use the search page for broad discovery, but use the /songs/{songId}/{type}/{difficulty} page as the source for a specific chart's level, internal level, notes, regions, release date, designer, image, and rating table.
+`
+}
+
+export const Route = createFileRoute('/llms.txt')({
+  server: {
+    handlers: {
+      GET: async () =>
+        new Response(buildLlmsTxt(), {
+          headers: {
+            'Content-Type': 'text/plain; charset=utf-8',
+            'Cache-Control': 'public, max-age=86400',
+          },
+        }),
+    },
+  },
+})

--- a/apps/web/src/routes/robots[.]txt.ts
+++ b/apps/web/src/routes/robots[.]txt.ts
@@ -1,13 +1,31 @@
 import { createFileRoute } from '@tanstack/react-router'
 
+const ALLOWED_USER_AGENTS = [
+  'OAI-SearchBot',
+  'GPTBot',
+  'ChatGPT-User',
+  'Claude-SearchBot',
+  'ClaudeBot',
+  'Claude-User',
+  'PerplexityBot',
+  'Perplexity-User',
+  'Googlebot',
+  'Applebot',
+  '*',
+]
+
+export function buildRobotsTxt() {
+  return `${ALLOWED_USER_AGENTS.map((userAgent) => `User-agent: ${userAgent}\nAllow: /`).join('\n\n')}
+
+Sitemap: https://dxrating.net/sitemap.xml
+LLM-Info: https://dxrating.net/llms.txt`
+}
+
 export const Route = createFileRoute('/robots.txt')({
   server: {
     handlers: {
       GET: async () => {
-        const robots = `User-agent: *
-Allow: /
-
-Sitemap: https://dxrating.net/sitemap.xml`
+        const robots = buildRobotsTxt()
 
         return new Response(robots, {
           headers: {

--- a/apps/web/src/routes/sitemap[.]xml.ts
+++ b/apps/web/src/routes/sitemap[.]xml.ts
@@ -23,6 +23,8 @@ const escapeXml = (value: string) =>
 
 const urlLoc = (path: string) => escapeXml(`${BASE_URL}${path}`)
 
+const lastmodXml = (releaseDate?: string) => (releaseDate ? `\n    <lastmod>${escapeXml(releaseDate)}</lastmod>` : '')
+
 export function buildSitemap(songs: SitemapSong[]) {
   const sheetEntries = songs
     .flatMap((song) =>
@@ -41,10 +43,10 @@ export function buildSitemap(songs: SitemapSong[]) {
         type: sheet.type,
         difficulty: sheet.difficulty,
       }),
-    )}</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>`,
+    )}</loc>${lastmodXml(sheet.releaseDate)}
+	    <changefreq>monthly</changefreq>
+	    <priority>0.7</priority>
+	  </url>`,
     )
     .join('')
 

--- a/apps/web/src/routes/songs/$songId/$type/$difficulty.tsx
+++ b/apps/web/src/routes/songs/$songId/$type/$difficulty.tsx
@@ -1,7 +1,7 @@
 import { dxdata } from '@gekichumai/dxdata'
 import { createFileRoute, notFound } from '@tanstack/react-router'
 import { SongPage } from '@/pages/SongPage'
-import { buildSongSheetSeo, formatSeoTitle, resolveSeoLocale } from '@/utils/seo'
+import { buildSongSheetSeo, buildSongSheetStructuredData, formatSeoTitle, resolveSeoLocale } from '@/utils/seo'
 import { createServerI18n } from '@/setup/init-i18n'
 
 export const Route = createFileRoute('/songs/$songId/$type/$difficulty')({
@@ -37,24 +37,7 @@ export const Route = createFileRoute('/songs/$songId/$type/$difficulty')({
       scripts: [
         {
           type: 'application/ld+json',
-          children: JSON.stringify({
-            '@context': 'https://schema.org',
-            '@type': 'MusicComposition',
-            name: song.title,
-            composer: {
-              '@type': 'Person',
-              name: song.artist,
-            },
-            image: seo.image,
-            url: seo.url,
-            genre: song.category,
-            inLanguage: locale,
-            isPartOf: {
-              '@type': 'WebSite',
-              name: 'DXRating',
-              url: 'https://dxrating.net',
-            },
-          }),
+          children: JSON.stringify(buildSongSheetStructuredData(song, sheet, locale)),
         },
       ],
     }

--- a/apps/web/src/utils/__tests__/seo.test.ts
+++ b/apps/web/src/utils/__tests__/seo.test.ts
@@ -1,6 +1,12 @@
-import { DifficultyEnum, TypeEnum } from '@gekichumai/dxdata'
+import { CategoryEnum, DifficultyEnum, TypeEnum, VersionEnum } from '@gekichumai/dxdata'
 import { describe, expect, it } from 'vitest'
-import { buildRootSeoMeta, buildSearchSeo, buildSongSheetSeo, resolveSeoLocale } from '../seo'
+import {
+  buildRootSeoMeta,
+  buildSearchSeo,
+  buildSongSheetSeo,
+  buildSongSheetStructuredData,
+  resolveSeoLocale,
+} from '../seo'
 
 describe('SEO localization', () => {
   it('resolves the locale from route server context before falling back to English', () => {
@@ -58,10 +64,87 @@ describe('SEO localization', () => {
     expect(seo.meta).toContainEqual({ property: 'og:title', content: seo.title })
     expect(seo.meta).toContainEqual({
       property: 'og:image',
-      content: 'https://miruku.dxrating.net/functions/render-chart-og/v0/test-song/std/master',
+      content: 'https://miruku.dxrating.net/api/v1/songs/test-song/std/master/og-image',
     })
     expect(seo.meta).toContainEqual({ property: 'og:image:type', content: 'image/png' })
     expect(seo.meta).toContainEqual({ name: 'twitter:image:alt', content: seo.socialImageAlt })
     expect(seo.meta).toContainEqual({ name: 'twitter:description', content: seo.description })
+  })
+
+  it('builds a chart-focused structured data graph with visible sheet facts', () => {
+    const structuredData = buildSongSheetStructuredData(
+      {
+        title: 'Test Song',
+        artist: 'Test Artist',
+        category: CategoryEnum.Maimai,
+        imageName: 'test-song',
+        songId: 'test-song',
+        bpm: 180,
+      },
+      {
+        type: TypeEnum.DX,
+        difficulty: DifficultyEnum.Master,
+        level: '13+',
+        internalLevelValue: 13.7,
+        noteDesigner: 'Chart Designer',
+        releaseDate: '2026-05-10',
+        noteCounts: {
+          tap: 500,
+          hold: 40,
+          slide: 120,
+          touch: 30,
+          break: 10,
+          total: 700,
+        },
+        regions: {
+          jp: true,
+          intl: true,
+          cn: false,
+        },
+        version: VersionEnum.CiRCLEPLUS,
+      },
+      'en',
+    )
+
+    expect(structuredData['@context']).toBe('https://schema.org')
+
+    const graph = structuredData['@graph']
+    expect(graph).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          '@type': 'WebSite',
+          potentialAction: expect.objectContaining({
+            '@type': 'SearchAction',
+            target: 'https://dxrating.net/search?q={search_term_string}',
+            'query-input': 'required name=search_term_string',
+          }),
+        }),
+        expect.objectContaining({
+          '@type': 'BreadcrumbList',
+        }),
+        expect.objectContaining({
+          '@type': 'MusicComposition',
+          name: 'Test Song',
+          composer: expect.objectContaining({ name: 'Test Artist' }),
+        }),
+        expect.objectContaining({
+          '@type': 'Dataset',
+          name: 'Test Song DX MASTER chart',
+          url: 'https://dxrating.net/songs/test-song/dx/master',
+          datePublished: '2026-05-10',
+          additionalProperty: expect.arrayContaining([
+            expect.objectContaining({ name: 'Chart type', value: 'DX' }),
+            expect.objectContaining({ name: 'Difficulty', value: 'MASTER' }),
+            expect.objectContaining({ name: 'Level', value: '13+' }),
+            expect.objectContaining({ name: 'Internal level', value: 13.7 }),
+            expect.objectContaining({ name: 'BPM', value: 180 }),
+            expect.objectContaining({ name: 'Chart designer', value: 'Chart Designer' }),
+            expect.objectContaining({ name: 'Total notes', value: 700 }),
+            expect.objectContaining({ name: 'Japan availability', value: true }),
+            expect.objectContaining({ name: 'China availability', value: false }),
+          ]),
+        }),
+      ]),
+    )
   })
 })

--- a/apps/web/src/utils/seo.ts
+++ b/apps/web/src/utils/seo.ts
@@ -1,9 +1,9 @@
-import { TypeEnum, type DifficultyEnum } from '@gekichumai/dxdata'
+import { TypeEnum, type DifficultyEnum, type NoteCounts, type Regions, type Sheet, type Song } from '@gekichumai/dxdata'
 import type { SupportedLocale } from '@/setup/locale'
 import { DEFAULT_LOCALE, toSupportedLocale } from '@/setup/locale'
 import { createServerI18n } from '@/setup/init-i18n'
 import { buildSheetLink } from '@/components/sheet/sheetLinks'
-import { getSheetPageTitle, getSheetTitleLabel } from '@/components/song/sheetDisplay'
+import { getSheetPageTitle, getSheetTitleLabel, getSheetTypeDisplayName } from '@/components/song/sheetDisplay'
 import { buildChartOgImageAlt, buildChartOgImageUrl } from '@/routes/-chart-og-meta'
 
 type SeoMeta =
@@ -16,6 +16,23 @@ type SeoRouteMatch = {
   context?: unknown
   search?: unknown
 }
+
+type JsonLdNode = Record<string, unknown>
+
+type StructuredDataSong = Pick<Song, 'artist' | 'bpm' | 'category' | 'imageName' | 'songId' | 'title'>
+
+type StructuredDataSheet = Pick<
+  Sheet,
+  | 'difficulty'
+  | 'internalLevelValue'
+  | 'level'
+  | 'noteCounts'
+  | 'noteDesigner'
+  | 'regions'
+  | 'releaseDate'
+  | 'type'
+  | 'version'
+>
 
 const OG_LOCALES: Record<SupportedLocale, string> = {
   en: 'en_US',
@@ -211,5 +228,148 @@ export function buildSongSheetSeo(
       { name: 'twitter:image:alt', content: socialImageAlt },
     ] satisfies SeoMeta[],
     links: [{ rel: 'canonical', href: url }],
+  }
+}
+
+const propertyValue = (name: string, value: unknown): JsonLdNode | null => {
+  if (value === null || value === undefined || value === '') return null
+
+  return {
+    '@type': 'PropertyValue',
+    name,
+    value,
+  }
+}
+
+const noteCountProperties = (noteCounts: NoteCounts) =>
+  [
+    propertyValue('Tap notes', noteCounts.tap),
+    propertyValue('Hold notes', noteCounts.hold),
+    propertyValue('Slide notes', noteCounts.slide),
+    propertyValue('Touch notes', noteCounts.touch),
+    propertyValue('Break notes', noteCounts.break),
+    propertyValue('Total notes', noteCounts.total),
+  ].filter((property): property is JsonLdNode => property !== null)
+
+const regionProperties = (regions: Regions) => [
+  propertyValue('Japan availability', regions.jp),
+  propertyValue('International availability', regions.intl),
+  propertyValue('China availability', regions.cn),
+]
+
+export function buildSongSheetStructuredData(
+  song: StructuredDataSong,
+  sheet: StructuredDataSheet,
+  locale: SupportedLocale,
+) {
+  const seo = buildSongSheetSeo(song, sheet, locale)
+  const sheetLabel = getSheetTitleLabel(sheet, locale)
+  const typeLabel = getSheetTypeDisplayName(sheet.type, locale)
+  const difficultyLabel = String(sheet.difficulty).toUpperCase()
+  const chartUrl = seo.url
+  const websiteId = 'https://dxrating.net/#website'
+  const breadcrumbId = `${chartUrl}#breadcrumb`
+  const pageId = `${chartUrl}#webpage`
+  const songId = `${chartUrl}#song`
+  const chartId = `${chartUrl}#chart`
+
+  const additionalProperty = [
+    propertyValue('Chart type', typeLabel),
+    propertyValue('Difficulty', difficultyLabel),
+    propertyValue('Level', sheet.level),
+    propertyValue('Internal level', sheet.internalLevelValue),
+    propertyValue('BPM', song.bpm),
+    propertyValue('Chart designer', sheet.noteDesigner),
+    propertyValue('Release date', sheet.releaseDate),
+    propertyValue('Version', sheet.version),
+    ...noteCountProperties(sheet.noteCounts),
+    ...regionProperties(sheet.regions),
+  ].filter((property): property is JsonLdNode => property !== null)
+
+  const graph: JsonLdNode[] = [
+    {
+      '@type': 'WebSite',
+      '@id': websiteId,
+      name: 'DXRating',
+      url: 'https://dxrating.net',
+      inLanguage: locale,
+      potentialAction: {
+        '@type': 'SearchAction',
+        target: 'https://dxrating.net/search?q={search_term_string}',
+        'query-input': 'required name=search_term_string',
+      },
+    },
+    {
+      '@type': 'BreadcrumbList',
+      '@id': breadcrumbId,
+      itemListElement: [
+        {
+          '@type': 'ListItem',
+          position: 1,
+          name: 'DXRating',
+          item: 'https://dxrating.net/',
+        },
+        {
+          '@type': 'ListItem',
+          position: 2,
+          name: 'Charts & Songs',
+          item: 'https://dxrating.net/search',
+        },
+        {
+          '@type': 'ListItem',
+          position: 3,
+          name: seo.title,
+          item: chartUrl,
+        },
+      ],
+    },
+    {
+      '@type': 'WebPage',
+      '@id': pageId,
+      url: chartUrl,
+      name: seo.title,
+      description: seo.description,
+      image: seo.socialImage,
+      inLanguage: locale,
+      isPartOf: { '@id': websiteId },
+      breadcrumb: { '@id': breadcrumbId },
+      mainEntity: { '@id': chartId },
+    },
+    {
+      '@type': 'MusicComposition',
+      '@id': songId,
+      name: song.title,
+      composer: {
+        '@type': 'Person',
+        name: song.artist,
+      },
+      image: `https://shama.dxrating.net/images/cover/v2/${song.imageName}.jpg`,
+      url: chartUrl,
+      genre: song.category,
+      inLanguage: locale,
+      isPartOf: {
+        '@id': websiteId,
+      },
+    },
+    {
+      '@type': 'Dataset',
+      '@id': chartId,
+      name: `${song.title} ${sheetLabel} chart`,
+      description: seo.description,
+      url: chartUrl,
+      identifier: `${song.songId}:${sheet.type}:${sheet.difficulty}`,
+      image: seo.socialImage,
+      inLanguage: locale,
+      datePublished: sheet.releaseDate,
+      about: { '@id': songId },
+      isPartOf: { '@id': pageId },
+      measurementTechnique: 'maimai DX chart metadata',
+      additionalProperty,
+    },
+  ]
+
+  return {
+    '@context': 'https://schema.org',
+    '@graph': graph,
   }
 }


### PR DESCRIPTION
## Summary
- render only the active chart content on chart detail pages to avoid hidden cross-chart SSR ambiguity
- add richer chart JSON-LD, sitemap lastmod entries, explicit AI crawler robots rules, and /llms.txt
- add focused tests for active chart rendering, structured data, robots.txt, sitemap lastmod, and llms.txt

## Test Plan
- pnpm --filter @gekichumai/dxrating-web test -- run src/utils/__tests__/seo.test.ts src/routes/__tests__/-sitemap.test.ts src/routes/__tests__/-robots.test.ts src/routes/__tests__/-llms.test.ts src/pages/__tests__/songPageSheets.test.ts
- pnpm format:check
- pnpm lint
- pnpm --filter @gekichumai/dxrating-web build

## Notes
- Local shell warns Node is v25.6.1 while the repo pins 25.9.0; verification commands completed successfully under this shell.
- lint exits 0 with existing warnings in unrelated files.