### PR TITLE
Preserve search caret position during route sync

### DIFF
--- a/apps/web/src/pages/SheetList.tsx
+++ b/apps/web/src/pages/SheetList.tsx
@@ -3,7 +3,7 @@ import { IconButton, TextField } from '@mui/material'
 import * as Sentry from '@sentry/tanstackstart-react'
 import { getRouteApi, useNavigate } from '@tanstack/react-router'
 import { usePostHog } from 'posthog-js/react'
-import { type FC, useCallback, useMemo, useState } from 'react'
+import { type FC, useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import IconMdiClose from '~icons/mdi/close'
 import MdiIconInfo from '~icons/mdi/information'
@@ -40,10 +40,16 @@ const SheetListInnerContent: FC<{ search: SearchParams }> = ({ search }) => {
   const navigate = useNavigate()
 
   const query = search.q ?? ''
-  const { results, elapsed: searchElapsed } = useFilteredSheets(query)
+  const [inputQuery, setInputQuery] = useState(query)
+  const { results, elapsed: searchElapsed } = useFilteredSheets(inputQuery)
+
+  useEffect(() => {
+    setInputQuery(query)
+  }, [query])
 
   const updateQuery = useCallback(
     (nextQuery: string) => {
+      setInputQuery(nextQuery)
       navigate({
         to: '/search',
         search: (prev: Record<string, unknown>) => ({
@@ -165,7 +171,7 @@ const SheetListInnerContent: FC<{ search: SearchParams }> = ({ search }) => {
           },
         )(sheet)
       })
-      if (!query) {
+      if (!inputQuery) {
         sortFilteredResults.sort((a, b) =>
           sortFilterOptions.sorts.reduce((acc, sort) => {
             if (acc !== 0) {
@@ -201,116 +207,114 @@ const SheetListInnerContent: FC<{ search: SearchParams }> = ({ search }) => {
     const elapsed = performance.now() - startTime
     Sentry.metrics.distribution('sheet_filter.duration', elapsed, {
       unit: 'millisecond',
-      attributes: { has_query: String(!!query), has_filters: String(!!sortFilterOptions) },
+      attributes: { has_query: String(!!inputQuery), has_filters: String(!!sortFilterOptions) },
     })
 
     return {
       filteredResults: sortFilteredResults,
       elapsed,
     }
-  }, [results, sortFilterOptions, query, version])
+  }, [results, sortFilterOptions, inputQuery, version])
 
   return (
-    <div className="flex-container pb-global">
-      <ResponsiveDialog
-        open={!!activeSheet}
-        setOpen={(open) => {
-          if (!open) handleSheetDialogChange(null)
-        }}
-      >
-        {() => activeSheet && <SheetDialogContent sheet={activeSheet} />}
-      </ResponsiveDialog>
+    <SheetDetailsContextProvider queryActive={!!inputQuery}>
+      <div className="flex-container pb-global">
+        <ResponsiveDialog
+          open={!!activeSheet}
+          setOpen={(open) => {
+            if (!open) handleSheetDialogChange(null)
+          }}
+        >
+          {() => activeSheet && <SheetDialogContent sheet={activeSheet} />}
+        </ResponsiveDialog>
 
-      <TextField
-        label={t('sheet:search')}
-        variant="outlined"
-        value={query}
-        fullWidth
-        onChange={(e) => {
-          updateQuery(e.target.value)
-        }}
-        InputProps={{
-          endAdornment: query && (
-            <IconButton
-              onClick={() => {
-                updateQuery('')
-                posthog?.capture('sheet_search_clear_button_clicked')
-              }}
-              size="small"
-            >
-              <IconMdiClose />
-            </IconButton>
-          ),
-        }}
-        data-attr="sheet-search"
-      />
+        <TextField
+          label={t('sheet:search')}
+          variant="outlined"
+          value={inputQuery}
+          fullWidth
+          onChange={(e) => {
+            updateQuery(e.target.value)
+          }}
+          InputProps={{
+            endAdornment: inputQuery && (
+              <IconButton
+                onClick={() => {
+                  updateQuery('')
+                  posthog?.capture('sheet_search_clear_button_clicked')
+                }}
+                size="small"
+              >
+                <IconMdiClose />
+              </IconButton>
+            ),
+          }}
+          data-attr="sheet-search"
+        />
 
-      <SheetSortFilter
-        onChange={(v) => {
-          setSortFilterOptions(v)
-        }}
-      />
-
-      <div className="text-sm rounded-full shadow-lg px-4 py-2 bg-blue-200 relative overflow-hidden select-none font-bold">
-        <div
-          className="absolute -inset-4 bg-blue-900/20 -skew-x-8 translate-x-4 transition-width"
-          style={{
-            width: `${(filteredResults.length / (sheets?.length ?? filteredResults.length)) * 100}%`,
+        <SheetSortFilter
+          onChange={(v) => {
+            setSortFilterOptions(v)
           }}
         />
-        <div className="relative z-1 flex items-center gap-2">
-          <MdiIconInfo className="text-blue-900" />
-          <div className="text-blue-900">
-            {t('sheet:search-summary', {
-              found: isLoading ? '...' : filteredResults.length,
-              total: isLoading ? '...' : sheets?.length,
-              elapsed: (searchElapsed + filteringElapsed).toFixed(1),
-            })}
+
+        <div className="text-sm rounded-full shadow-lg px-4 py-2 bg-blue-200 relative overflow-hidden select-none font-bold">
+          <div
+            className="absolute -inset-4 bg-blue-900/20 -skew-x-8 translate-x-4 transition-width"
+            style={{
+              width: `${(filteredResults.length / (sheets?.length ?? filteredResults.length)) * 100}%`,
+            }}
+          />
+          <div className="relative z-1 flex items-center gap-2">
+            <MdiIconInfo className="text-blue-900" />
+            <div className="text-blue-900">
+              {t('sheet:search-summary', {
+                found: isLoading ? '...' : filteredResults.length,
+                total: isLoading ? '...' : sheets?.length,
+                elapsed: (searchElapsed + filteringElapsed).toFixed(1),
+              })}
+            </div>
           </div>
         </div>
-      </div>
 
-      {isLoading ? (
-        <div className="flex flex-col w-full">
-          {skeletonWidths.map((width, i) => (
-            <div
-              className="animate-pulse flex items-center justify-start gap-4 w-full h-[78px] px-5 py-2"
-              // oxlint-disable-next-line react/no-array-index-key -- index is stable
-              key={i}
-              style={{
-                animationDelay: `${i * 40}ms`,
-              }}
-            >
-              <div className="h-12 w-12 min-w-[3rem] min-h-[3rem] rounded bg-slate-6/50" />
-              <div className="flex flex-col gap-1">
-                <div className="bg-slate-5/50 h-5 mb-1" style={{ width: `${width}rem` }}>
-                  &nbsp;
+        {isLoading ? (
+          <div className="flex flex-col w-full">
+            {skeletonWidths.map((width, i) => (
+              <div
+                className="animate-pulse flex items-center justify-start gap-4 w-full h-[78px] px-5 py-2"
+                // oxlint-disable-next-line react/no-array-index-key -- index is stable
+                key={i}
+                style={{
+                  animationDelay: `${i * 40}ms`,
+                }}
+              >
+                <div className="h-12 w-12 min-w-[3rem] min-h-[3rem] rounded bg-slate-6/50" />
+                <div className="flex flex-col gap-1">
+                  <div className="bg-slate-5/50 h-5 mb-1" style={{ width: `${width}rem` }}>
+                    &nbsp;
+                  </div>
+                  <div className="w-24 bg-slate-3/50 h-3">&nbsp;</div>
                 </div>
-                <div className="w-24 bg-slate-3/50 h-3">&nbsp;</div>
-              </div>
 
-              <div className="flex-1" />
-              <div className="w-10 bg-slate-5/50 h-6 mr-2">&nbsp;</div>
-            </div>
-          ))}
-        </div>
-      ) : (
-        <SheetListContainer
-          sheets={filteredResults}
-          activeSheetId={activeSheetId}
-          onSheetDialogChange={handleSheetDialogChange}
-        />
-      )}
-    </div>
+                <div className="flex-1" />
+                <div className="w-10 bg-slate-5/50 h-6 mr-2">&nbsp;</div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <SheetListContainer
+            sheets={filteredResults}
+            activeSheetId={activeSheetId}
+            onSheetDialogChange={handleSheetDialogChange}
+          />
+        )}
+      </div>
+    </SheetDetailsContextProvider>
   )
 }
 
 export const SheetList: FC = () => {
   const search = searchRouteApi.useSearch()
 
-  return (
-    <SheetDetailsContextProvider queryActive={!!search.q}>
-      <SheetListInnerContent search={search} />
-    </SheetDetailsContextProvider>
-  )
+  return <SheetListInnerContent search={search} />
 }

--- a/apps/web/src/pages/__tests__/SheetList.test.tsx
+++ b/apps/web/src/pages/__tests__/SheetList.test.tsx
@@ -1,0 +1,123 @@
+import { VersionEnum } from '@gekichumai/dxdata'
+import { fireEvent, render, screen, type RenderResult } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { initI18n } from '@/setup/init-i18n'
+import { SheetList } from '../SheetList'
+
+const routeState = vi.hoisted(() => {
+  const state: {
+    search: Record<string, unknown>
+    pendingSearch?: Record<string, unknown>
+    syncSearchOnNavigate: boolean
+    onNavigate?: () => void
+    navigate: ReturnType<typeof vi.fn>
+  } = {
+    search: {},
+    syncSearchOnNavigate: true,
+    navigate: vi.fn((options: { search?: Record<string, unknown> | ((prev: Record<string, unknown>) => unknown) }) => {
+      let nextSearch = state.search
+      if (typeof options.search === 'function') {
+        nextSearch = options.search(state.search) as Record<string, unknown>
+      } else if (options.search) {
+        nextSearch = options.search
+      }
+
+      if (state.syncSearchOnNavigate) {
+        state.search = nextSearch
+      } else {
+        state.pendingSearch = nextSearch
+      }
+      state.onNavigate?.()
+    }),
+  }
+
+  return state
+})
+
+vi.mock('@tanstack/react-router', () => ({
+  getRouteApi: () => ({
+    useSearch: () => routeState.search,
+  }),
+  useNavigate: () => routeState.navigate,
+}))
+
+vi.mock('@sentry/tanstackstart-react', () => ({
+  metrics: {
+    distribution: vi.fn(),
+  },
+}))
+
+vi.mock('posthog-js/react', () => ({
+  usePostHog: () => null,
+}))
+
+vi.mock('@/models/context/useAppContext', () => ({
+  useAppContextDXDataVersion: () => VersionEnum.CiRCLEPLUS,
+}))
+
+vi.mock('@/songs', () => ({
+  canonicalIdFromParts: (...parts: string[]) => parts.join(':'),
+  useFilteredSheets: () => ({ results: [], elapsed: 0 }),
+  useSheets: () => ({ data: [], isLoading: false }),
+}))
+
+vi.mock('@/components/global/ResponsiveDialog', () => ({
+  ResponsiveDialog: ({ children }: { children: () => ReactNode }) => <>{children()}</>,
+}))
+
+vi.mock('@/components/sheet/SheetDialogContent', () => ({
+  SheetDialogContent: () => null,
+}))
+
+vi.mock('@/components/sheet/SheetListContainer', () => ({
+  SheetListContainer: () => <div data-testid="sheet-list" />,
+}))
+
+vi.mock('@/components/sheet/SheetSortFilter', () => ({
+  SheetSortFilter: () => <div data-testid="sheet-sort-filter" />,
+}))
+
+describe('SheetList', () => {
+  beforeAll(() => {
+    initI18n()
+  })
+
+  beforeEach(() => {
+    routeState.search = {}
+    routeState.pendingSearch = undefined
+    routeState.syncSearchOnNavigate = true
+    routeState.onNavigate = undefined
+    routeState.navigate.mockClear()
+  })
+
+  it('keeps an in-progress search edit when the route query update is pending', () => {
+    routeState.search = { q: 'abcdef' }
+    routeState.syncSearchOnNavigate = false
+    let view: RenderResult
+    routeState.onNavigate = () => {
+      view.rerender(<SheetList />)
+    }
+
+    view = render(<SheetList />)
+
+    const input = screen.getByRole('textbox', { name: 'Search' }) as HTMLInputElement
+    input.focus()
+    input.setSelectionRange(4, 4)
+
+    fireEvent.change(input, {
+      target: { value: 'abcd1ef', selectionStart: 5, selectionEnd: 5 },
+    })
+
+    expect(input.value).toBe('abcd1ef')
+    expect(input.selectionStart).toBe(5)
+    expect(input.selectionEnd).toBe(5)
+
+    routeState.search = routeState.pendingSearch ?? routeState.search
+    view.rerender(<SheetList />)
+
+    expect(input.value).toBe('abcd1ef')
+    expect(input.selectionStart).toBe(5)
+    expect(input.selectionEnd).toBe(5)
+  })
+})


### PR DESCRIPTION
## Summary
- Keep the search box on a local draft value while route query updates settle.
- Drive search results, clear-button state, and query-active context from the immediate input value.
- Add a regression test for inserting text in the middle of the search query without moving the caret to the end.

## Test Plan
- [x] pnpm test run src/pages/__tests__/SheetList.test.tsx
- [x] pnpm --filter @gekichumai/dxrating-web build
- [x] pnpm format:check
- [x] pnpm lint