### PR TITLE
Render trending charts with SSR

### DIFF
--- a/apps/web/src/pages/TrendingPage.tsx
+++ b/apps/web/src/pages/TrendingPage.tsx
@@ -4,7 +4,13 @@ import { useMemo, type FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { buildTrendingChartLinks } from '@/components/chartDiscovery/trendingCharts'
 import { SheetListItem } from '@/components/sheet/SheetListItem'
-import { orpc } from '@/lib/orpc'
+import { orpc, type RouterOutputs } from '@/lib/orpc'
+
+type TrendingData = RouterOutputs['analytics']['trending']
+
+type TrendingPageProps = {
+  initialTrendingData?: TrendingData
+}
 
 const siteUrl = 'https://dxrating.net'
 
@@ -37,9 +43,11 @@ const TrendingChartsSkeleton: FC<{ label: string }> = ({ label }) => (
   </div>
 )
 
-export const TrendingPage: FC = () => {
+export const TrendingPage: FC<TrendingPageProps> = ({ initialTrendingData }) => {
   const { t } = useTranslation(['sheet'])
-  const trendingQuery = useQuery(orpc.analytics.trending.queryOptions({ staleTime: 60 * 60 * 1000 }))
+  const trendingQuery = useQuery(
+    orpc.analytics.trending.queryOptions({ initialData: initialTrendingData, staleTime: 60 * 60 * 1000 }),
+  )
   const trendingResults = trendingQuery.data?.results
   const charts = useMemo(() => (trendingResults ? buildTrendingChartLinks(trendingResults) : []), [trendingResults])
   const hasDateRange = !!trendingQuery.data?.dateFrom && !!trendingQuery.data?.dateTo

--- a/apps/web/src/pages/__tests__/TrendingPage.test.tsx
+++ b/apps/web/src/pages/__tests__/TrendingPage.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, within } from '@testing-library/react'
+import { renderToString } from 'react-dom/server'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { initI18n } from '@/setup/init-i18n'
 import { TrendingPage } from '../TrendingPage'
@@ -35,14 +36,18 @@ const mocks = vi.hoisted(() => {
 })
 
 vi.mock('@tanstack/react-query', () => ({
-  useQuery: () => mocks.queryState,
+  useQuery: (options: { initialData?: typeof mocks.queryState.data }) => ({
+    ...mocks.queryState,
+    data: mocks.queryState.data ?? options.initialData,
+    isLoading: mocks.queryState.data || options.initialData ? false : mocks.queryState.isLoading,
+  }),
 }))
 
 vi.mock('@/lib/orpc', () => ({
   orpc: {
     analytics: {
       trending: {
-        queryOptions: vi.fn(),
+        queryOptions: vi.fn((options) => options),
       },
     },
   },
@@ -87,6 +92,28 @@ describe('TrendingPage', () => {
     const sheetListItem = screen.getByTestId('sheet-list-item')
     expect(sheetListItem.textContent).toBe('Song A')
     expect(sheetListItem.getAttribute('href')).toBe('/songs/song-a/dx/master')
+  })
+
+  it('renders crawlable chart anchors in server HTML from initial trending data', () => {
+    mocks.queryState.data = null
+
+    const html = renderToString(
+      <TrendingPage
+        initialTrendingData={{
+          dateFrom: '2026-05-01',
+          dateTo: '2026-05-24',
+          results: mocks.results,
+        }}
+      />,
+    )
+
+    expect(html).toContain('href="/songs/song-a/dx/master"')
+    expect(html).toContain('itemType="https://schema.org/CollectionPage"')
+    expect(html).toContain('itemType="https://schema.org/ItemList"')
+    expect(html).toContain('itemType="https://schema.org/ListItem"')
+    expect(html).toContain('itemType="https://schema.org/MusicRecording"')
+    expect(html).toContain('Song A')
+    expect(html).not.toContain('Loading trending charts...')
   })
 
   it('memoizes chart mapping while the trending results reference is unchanged', () => {

--- a/apps/web/src/routes/__tests__/-charts-trending.test.tsx
+++ b/apps/web/src/routes/__tests__/-charts-trending.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest'
+import { apiClient } from '@/lib/orpc'
+import { Route, loadTrendingRouteData } from '../charts/trending'
+
+const mocks = vi.hoisted(() => ({
+  trending: vi.fn(),
+}))
+
+vi.mock('@/lib/orpc', () => ({
+  apiClient: {
+    analytics: {
+      trending: mocks.trending,
+    },
+  },
+}))
+
+vi.mock('@/pages/TrendingPage', () => ({
+  TrendingPage: () => null,
+}))
+
+describe('/charts/trending route', () => {
+  it('fetches trending data during SSR', async () => {
+    const trendingData = {
+      dateFrom: '2026-05-01',
+      dateTo: '2026-05-24',
+      results: [{ songId: 'song-a' }],
+    }
+
+    mocks.trending.mockResolvedValueOnce(trendingData)
+
+    expect(Route.options.ssr).toBe(true)
+    await expect(loadTrendingRouteData()).resolves.toEqual({ trendingData })
+    expect(apiClient.analytics.trending).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/src/routes/charts/trending.tsx
+++ b/apps/web/src/routes/charts/trending.tsx
@@ -1,9 +1,15 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { TrendingPage } from '@/pages/TrendingPage'
 import { buildTrendingChartsSeo, resolveSeoLocale } from '@/utils/seo'
+import { apiClient } from '@/lib/orpc'
+
+export const loadTrendingRouteData = async () => ({
+  trendingData: await apiClient.analytics.trending(),
+})
 
 export const Route = createFileRoute('/charts/trending')({
-  ssr: false,
+  ssr: true,
+  loader: loadTrendingRouteData,
   head: ({ match, matches }) => {
     const seo = buildTrendingChartsSeo(resolveSeoLocale([match, ...matches]))
 
@@ -12,5 +18,11 @@ export const Route = createFileRoute('/charts/trending')({
       links: seo.links,
     }
   },
-  component: TrendingPage,
+  component: TrendingRouteComponent,
 })
+
+function TrendingRouteComponent() {
+  const { trendingData } = Route.useLoaderData()
+
+  return <TrendingPage initialTrendingData={trendingData} />
+}


### PR DESCRIPTION
## Summary
- Enable SSR for `/charts/trending` and fetch trending analytics data in the route loader
- Seed `TrendingPage` with loader data so server HTML includes crawlable chart links
- Add route/page tests for SSR data loading and initial server-rendered anchors

## Test Plan
- `pnpm --filter @gekichumai/dxrating-web exec vitest run`
- `pnpm --filter @gekichumai/dxrating-web build`
- `pnpm lint`
- `pnpm format:check`
