### PR TITLE
Fix blank root route

### DIFF
--- a/apps/web/src/pages/SongPage.tsx
+++ b/apps/web/src/pages/SongPage.tsx
@@ -109,7 +109,7 @@ export const SongPage: FC = () => {
   return (
     <div className="max-w-2xl mx-auto px-4 py-6 flex flex-col gap-4">
       <a
-        href="/"
+        href="/search"
         onClick={(e) => {
           if (window.history.length > 1 && document.referrer.startsWith(window.location.origin)) {
             e.preventDefault()

--- a/apps/web/src/pages/__tests__/SongPage.test.tsx
+++ b/apps/web/src/pages/__tests__/SongPage.test.tsx
@@ -58,4 +58,10 @@ describe('SongPage', () => {
     expect(document.head.querySelectorAll('title')).toHaveLength(1)
     expect(document.head.querySelector('title')?.textContent).toBe('Route-owned title')
   })
+
+  it('uses search as the client fallback for the back link', () => {
+    const { container } = render(<SongPage />)
+
+    expect(container.querySelector('a')?.getAttribute('href')).toBe('/search')
+  })
 })

--- a/apps/web/src/routes/__tests__/-index.test.ts
+++ b/apps/web/src/routes/__tests__/-index.test.ts
@@ -1,0 +1,30 @@
+import { isRedirect } from '@tanstack/react-router'
+import { describe, expect, it } from 'vitest'
+import { Route } from '../index'
+
+describe('index route', () => {
+  it('runs during SSR so the server redirects instead of rendering an empty outlet', () => {
+    expect(Route.options.ssr).not.toBe(false)
+  })
+
+  it('redirects root visits to search while preserving the URL suffix', () => {
+    try {
+      Route.options.beforeLoad?.({
+        location: {
+          searchStr: '?locale=ja',
+          hash: '#songs',
+        },
+      } as never)
+    } catch (error) {
+      expect(isRedirect(error)).toBe(true)
+      expect(error).toMatchObject({
+        options: {
+          href: '/search?locale=ja#songs',
+        },
+      })
+      return
+    }
+
+    throw new Error('Expected the index route to redirect')
+  })
+})

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute, redirect } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/')({
-  ssr: false,
   head: () => ({
     links: [{ rel: 'canonical', href: 'https://dxrating.net' }],
   }),


### PR DESCRIPTION
## Summary
- allow the root index route to run during SSR so / redirects before rendering an empty outlet
- change the song page back-link fallback from / to /search for client-side navigation
- add regression tests for the root redirect and song page fallback link

## Test Plan
- pnpm vitest run src/pages/__tests__/SongPage.test.tsx src/routes/__tests__/-index.test.ts
- pnpm --filter @gekichumai/dxrating-web build