### PR TITLE
Consolidate SheetListItem focus target

### DIFF
--- a/apps/web/src/components/sheet/SheetListItem.tsx
+++ b/apps/web/src/components/sheet/SheetListItem.tsx
@@ -48,7 +48,8 @@ export const SheetListItem: FC<{
           </ResponsiveDialog>
         )}
 
-        <a
+        <ListItemButton
+          component="a"
           href={buildSheetPath(sheet)}
           onClick={(e) => {
             if (e.metaKey || e.ctrlKey || e.shiftKey || e.button === 1) return
@@ -61,20 +62,15 @@ export const SheetListItem: FC<{
               sheet_difficulty: sheet.difficulty,
             })
           }}
-          className="no-underline text-inherit"
+          disableGutters={!isLargeDevice}
+          className={clsx(
+            'w-full cursor-pointer transition duration-500 hover:duration-25 !px-4 no-underline text-inherit',
+            open && '!bg-zinc-300/80',
+          )}
+          sx={{ borderRadius: 1 }}
         >
-          <ListItemButton
-            disableGutters={!isLargeDevice}
-            className={clsx(
-              'w-full cursor-pointer transition duration-500 hover:duration-25 !px-4',
-              open && '!bg-zinc-300/80',
-            )}
-            sx={{ borderRadius: 1 }}
-            component="div"
-          >
-            <SheetListItemContent sheet={sheet} size={size} {...SheetListItemContentProps} />
-          </ListItemButton>
-        </a>
+          <SheetListItemContent sheet={sheet} size={size} {...SheetListItemContentProps} />
+        </ListItemButton>
       </>
     )
   },

--- a/apps/web/src/components/sheet/__tests__/SheetListItem.test.tsx
+++ b/apps/web/src/components/sheet/__tests__/SheetListItem.test.tsx
@@ -1,9 +1,19 @@
 import { CategoryEnum, DifficultyEnum, TypeEnum, VersionEnum } from '@gekichumai/dxdata'
 import { render, screen } from '@testing-library/react'
-import { beforeAll, describe, expect, it } from 'vitest'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
 import { initI18n } from '@/setup/init-i18n'
 import type { FlattenedSheet } from '@/songs'
-import { SheetListItemContent } from '../SheetListItem'
+import { SheetListItem, SheetListItemContent } from '../SheetListItem'
+
+vi.mock('posthog-js/react', () => ({
+  usePostHog: () => null,
+}))
+
+vi.mock('web-haptics/react', () => ({
+  useWebHaptics: () => ({
+    trigger: vi.fn(),
+  }),
+}))
 
 function makeSheet(type: TypeEnum): FlattenedSheet {
   return {
@@ -50,6 +60,29 @@ function makeSheet(type: TypeEnum): FlattenedSheet {
     tags: [],
   }
 }
+
+const getFocusableElements = (container: HTMLElement) =>
+  Array.from(
+    container.querySelectorAll<HTMLElement>(
+      'a[href], button, input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    ),
+  ).filter((element) => !element.hasAttribute('disabled') && element.getAttribute('aria-hidden') !== 'true')
+
+describe('SheetListItem', () => {
+  beforeAll(() => {
+    initI18n()
+  })
+
+  it('renders the row as a single focusable link', () => {
+    const { container } = render(<SheetListItem sheet={makeSheet(TypeEnum.DX)} />)
+
+    const sheetLink = screen.getByRole('link', { name: /Song Title/ })
+    const focusableElements = getFocusableElements(container)
+
+    expect(focusableElements).toHaveLength(1)
+    expect(focusableElements[0]).toBe(sheetLink)
+  })
+})
 
 describe('SheetListItemContent', () => {
   beforeAll(() => {


### PR DESCRIPTION
## Summary
- Render `SheetListItem` as one anchor-backed `ListItemButton` instead of nesting a focusable button surface inside a link.
- Keep the existing dialog-opening click behavior, link URL, active styling, haptics, and PostHog event on that single element.
- Add a regression test asserting the row exposes exactly one focusable link.

## Test Plan
- [x] `pnpm --filter @gekichumai/dxrating-web exec vitest run src/components/sheet/__tests__/SheetListItem.test.tsx`
- [x] `pnpm format:check`
- [x] `pnpm lint` (exits 0; existing warnings remain outside this diff)
- [x] `pnpm --filter @gekichumai/dxrating-web build`
