### PR TITLE
Move sheet filters into compact search trigger

### DIFF
--- a/apps/web/src/components/sheet/SheetSortFilter.tsx
+++ b/apps/web/src/components/sheet/SheetSortFilter.tsx
@@ -18,6 +18,7 @@ import { FormProvider, useForm, useFormContext } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { useEffectOnce } from 'react-use'
 import MdiChevronDownIcon from '~icons/mdi/chevron-down'
+import MdiFilterIcon from '~icons/mdi/filter'
 import { SheetDetailsContext } from '../../models/context/SheetDetailsContext'
 import type { FlattenedSheet } from '../../songs'
 import { SheetSortSelect } from './SheetSortSelect'
@@ -206,7 +207,11 @@ const loadSavedSheetSortFilterForm = (): SheetSortFilterForm | null => {
 
 export const SheetSortFilter: FC<{
   onChange?: (form: SheetSortFilterForm) => void
-}> = ({ onChange }) => {
+  expanded?: boolean
+  contentId?: string
+  onExpandedChange?: (expanded: boolean) => void
+  showDefaultTrigger?: boolean
+}> = ({ onChange, expanded, contentId, onExpandedChange, showDefaultTrigger }) => {
   const methods = useForm<SheetSortFilterForm>({
     mode: 'onChange',
     defaultValues: getDefaultSheetSortFilterForm(),
@@ -227,7 +232,12 @@ export const SheetSortFilter: FC<{
   return (
     <FormProvider {...methods}>
       <SheetSortFilterFormListener onChange={onChange} />
-      <SheetSortFilterFormContent />
+      <SheetSortFilterFormContent
+        expanded={expanded}
+        contentId={contentId}
+        onExpandedChange={onExpandedChange}
+        showDefaultTrigger={showDefaultTrigger}
+      />
     </FormProvider>
   )
 }
@@ -301,13 +311,83 @@ const SheetSortFilterFormReset: FC<{
   )
 }
 
-const SheetSortFilterFormContent = () => {
+export const SheetSortFilterTrigger: FC<{
+  expanded: boolean
+  contentId: string
+  onToggle: () => void
+  pending?: boolean
+  variant?: 'bar' | 'compact'
+  className?: string
+}> = ({ expanded, contentId, onToggle, pending = false, variant = 'bar', className }) => {
+  const { t } = useTranslation(['sheet'])
+
+  if (variant === 'compact') {
+    return (
+      <ButtonBase
+        className={clsx(
+          'relative min-h-[56px] w-[4.75rem] shrink-0 rounded border px-2 py-1.5 transition-all duration-300',
+          'flex items-center justify-center gap-1.5 text-zinc-900 shadow-sm backdrop-blur-sm',
+          expanded ? 'border-zinc-500 bg-gray-200' : 'border-zinc-400/70 bg-white/70 hover:bg-white/90',
+          className,
+        )}
+        aria-label={t('sheet:sort-and-filter.title')}
+        aria-controls={contentId}
+        aria-expanded={expanded}
+        onClick={onToggle}
+      >
+        <MdiFilterIcon className="h-5 w-5 shrink-0" />
+        <span className="flex flex-col text-left text-[0.7rem] font-bold leading-[0.9rem] tracking-normal">
+          <span className="whitespace-nowrap">{t('sheet:filter.title')}</span>
+          <span className="whitespace-nowrap">{t('sheet:sort.title')}</span>
+        </span>
+        {pending && <CircularProgress disableShrink className="absolute right-1 top-1 !h-3 !w-3" />}
+      </ButtonBase>
+    )
+  }
+
+  return (
+    <ButtonBase
+      className={clsx(
+        'px-4 w-full flex items-center transition-all duration-300',
+        expanded ? 'bg-gray-200 py-4' : 'bg-gray-100 py-3',
+        className,
+      )}
+      aria-controls={contentId}
+      aria-expanded={expanded}
+      onClick={onToggle}
+    >
+      <div className="text-xl font-bold tracking-tight leading-none">{t('sheet:sort-and-filter.title')}</div>
+      {pending && <CircularProgress disableShrink className="ml-2 !h-4 !w-4" />}
+      <div className="flex-1" />
+      <MdiChevronDownIcon className={clsx('w-6 h-6 transition-transform', expanded && 'transform rotate-180')} />
+    </ButtonBase>
+  )
+}
+
+const SheetSortFilterFormContent: FC<{
+  expanded?: boolean
+  contentId?: string
+  onExpandedChange?: (expanded: boolean) => void
+  showDefaultTrigger?: boolean
+}> = ({ expanded: controlledExpanded, contentId, onExpandedChange, showDefaultTrigger = true }) => {
   const { t } = useTranslation(['sheet'])
   const { queryActive } = useContext(SheetDetailsContext)
   const { control, setValue, reset } = useFormContext<SheetSortFilterForm>()
-  const [expanded, setExpanded] = useState(false)
+  const [uncontrolledExpanded, setUncontrolledExpanded] = useState(false)
   const [pending, startTransition] = useTransition()
-  const contentId = useId()
+  const generatedContentId = useId()
+  const resolvedContentId = contentId ?? generatedContentId
+  const expanded = controlledExpanded ?? uncontrolledExpanded
+
+  const toggleExpanded = () => {
+    startTransition(() => {
+      const nextExpanded = !expanded
+      if (controlledExpanded === undefined) {
+        setUncontrolledExpanded(nextExpanded)
+      }
+      onExpandedChange?.(nextExpanded)
+    })
+  }
 
   const resetByFilter = (...filters: (keyof SheetSortFilterForm['filters'])[]) => {
     const defaultForm = getDefaultSheetSortFilterForm()
@@ -363,24 +443,20 @@ const SheetSortFilterFormContent = () => {
   return (
     <>
       {import.meta.env.DEV && <DevTool control={control} />}
-      <Paper className="w-full flex flex-col overflow-hidden">
-        <ButtonBase
-          className={clsx(
-            'px-4 w-full flex items-center transition-all duration-300',
-            expanded ? 'bg-gray-200 py-4' : 'bg-gray-100 py-3',
+      {(showDefaultTrigger || expanded) && (
+        <Paper className="w-full flex flex-col overflow-hidden">
+          {showDefaultTrigger && (
+            <SheetSortFilterTrigger
+              expanded={expanded}
+              contentId={resolvedContentId}
+              onToggle={toggleExpanded}
+              pending={pending}
+            />
           )}
-          aria-controls={contentId}
-          aria-expanded={expanded}
-          onClick={() => startTransition(() => setExpanded((current) => !current))}
-        >
-          <div className="text-xl font-bold tracking-tight leading-none">{t('sheet:sort-and-filter.title')}</div>
-          {pending && <CircularProgress disableShrink className="ml-2 !h-4 !w-4" />}
-          <div className="flex-1" />
-          <MdiChevronDownIcon className={clsx('w-6 h-6 transition-transform', expanded && 'transform rotate-180')} />
-        </ButtonBase>
 
-        {expanded && <div id={contentId}>{collapsibleInner}</div>}
-      </Paper>
+          {expanded && <div id={resolvedContentId}>{collapsibleInner}</div>}
+        </Paper>
+      )}
     </>
   )
 }

--- a/apps/web/src/components/sheet/SheetSortFilter.tsx
+++ b/apps/web/src/components/sheet/SheetSortFilter.tsx
@@ -3,6 +3,7 @@ import { DevTool } from '@hookform/devtools'
 import {
   Button,
   ButtonBase,
+  Collapse,
   CircularProgress,
   Dialog,
   DialogActions,
@@ -448,19 +449,25 @@ const SheetSortFilterFormContent: FC<{
   return (
     <>
       {import.meta.env.DEV && <DevTool control={control} />}
-      {(showDefaultTrigger || expanded) && (
+      {showDefaultTrigger ? (
         <Paper className="w-full flex flex-col overflow-hidden">
-          {showDefaultTrigger && (
-            <SheetSortFilterTrigger
-              expanded={expanded}
-              contentId={resolvedContentId}
-              onToggle={toggleExpanded}
-              pending={pending}
-            />
-          )}
+          <SheetSortFilterTrigger
+            expanded={expanded}
+            contentId={resolvedContentId}
+            onToggle={toggleExpanded}
+            pending={pending}
+          />
 
-          {expanded && <div id={resolvedContentId}>{collapsibleInner}</div>}
+          <Collapse className="w-full" in={expanded} timeout={275} unmountOnExit>
+            <div id={resolvedContentId}>{collapsibleInner}</div>
+          </Collapse>
         </Paper>
+      ) : (
+        <Collapse className="w-full" in={expanded} timeout={275} unmountOnExit>
+          <Paper className="w-full flex flex-col overflow-hidden">
+            <div id={resolvedContentId}>{collapsibleInner}</div>
+          </Paper>
+        </Collapse>
       )}
     </>
   )

--- a/apps/web/src/components/sheet/SheetSortFilter.tsx
+++ b/apps/web/src/components/sheet/SheetSortFilter.tsx
@@ -387,11 +387,16 @@ const SheetSortFilterFormContent: FC<{
 
   const toggleExpanded = () => {
     startTransition(() => {
-      const nextExpanded = !expanded
       if (controlledExpanded === undefined) {
-        setUncontrolledExpanded(nextExpanded)
+        setUncontrolledExpanded((currentExpanded) => {
+          const nextExpanded = !currentExpanded
+          onExpandedChange?.(nextExpanded)
+          return nextExpanded
+        })
+        return
       }
-      onExpandedChange?.(nextExpanded)
+
+      onExpandedChange?.(!controlledExpanded)
     })
   }
 

--- a/apps/web/src/components/sheet/SheetSortFilter.tsx
+++ b/apps/web/src/components/sheet/SheetSortFilter.tsx
@@ -384,6 +384,17 @@ const SheetSortFilterFormContent: FC<{
   const generatedContentId = useId()
   const resolvedContentId = contentId ?? generatedContentId
   const expanded = controlledExpanded ?? uncontrolledExpanded
+  const [contentMotionVisible, setContentMotionVisible] = useState(expanded)
+
+  useEffect(() => {
+    if (!expanded) {
+      setContentMotionVisible(false)
+      return
+    }
+
+    const animationFrame = window.requestAnimationFrame(() => setContentMotionVisible(true))
+    return () => window.cancelAnimationFrame(animationFrame)
+  }, [expanded])
 
   const toggleExpanded = () => {
     startTransition(() => {
@@ -407,9 +418,16 @@ const SheetSortFilterFormContent: FC<{
     }
   }
 
+  const contentMotionClassName = clsx(
+    'origin-top transition-[opacity,transform,filter] duration-[275ms] ease-[cubic-bezier(0.2,0,0,1)]',
+    contentMotionVisible
+      ? 'opacity-100 translate-y-0 scale-100 blur-0'
+      : 'opacity-0 -translate-y-1 scale-[0.995] blur-[1px]',
+  )
+
   const collapsibleInner = (
     <div className="p-2 w-full flex flex-col gap-4">
-      <div className="m-2 flex flex-col gap-4">
+      <div className="p-2 flex flex-col gap-4">
         <div className="flex">
           <SheetSortFilterFormReset
             onReset={() => {
@@ -464,13 +482,17 @@ const SheetSortFilterFormContent: FC<{
           />
 
           <Collapse className="w-full" in={expanded} timeout={275} unmountOnExit>
-            <div id={resolvedContentId}>{collapsibleInner}</div>
+            <div id={resolvedContentId} className={contentMotionClassName}>
+              {collapsibleInner}
+            </div>
           </Collapse>
         </Paper>
       ) : (
         <Collapse className="w-full" in={expanded} timeout={275} unmountOnExit>
           <Paper className="w-full flex flex-col overflow-hidden">
-            <div id={resolvedContentId}>{collapsibleInner}</div>
+            <div id={resolvedContentId} className={contentMotionClassName}>
+              {collapsibleInner}
+            </div>
           </Paper>
         </Collapse>
       )}

--- a/apps/web/src/components/sheet/SheetSortFilter.tsx
+++ b/apps/web/src/components/sheet/SheetSortFilter.tsx
@@ -323,11 +323,13 @@ export const SheetSortFilterTrigger: FC<{
 
   if (variant === 'compact') {
     return (
-      <ButtonBase
+      <Button
+        variant="outlined"
+        color="inherit"
         className={clsx(
-          'relative min-h-[56px] w-[6.25rem] shrink-0 rounded-[4px] border px-3 py-1.5 transition-all duration-300',
-          'flex items-center justify-center gap-1.5 text-zinc-900 shadow-sm backdrop-blur-sm',
-          expanded ? 'border-zinc-500 bg-gray-200' : 'border-zinc-400/70 bg-white/70 hover:bg-white/90',
+          'relative !min-h-[56px] !min-w-[6.25rem] shrink-0 !px-3 !py-1.5 !normal-case transition-all duration-300',
+          '!flex !items-center !justify-center gap-1.5 !text-zinc-900 shadow-sm backdrop-blur-sm',
+          expanded ? '!border-zinc-500 !bg-gray-200' : '!border-zinc-400/70 !bg-white/70 hover:!bg-white/90',
           className,
         )}
         aria-label={t('sheet:sort-and-filter.title')}
@@ -344,7 +346,7 @@ export const SheetSortFilterTrigger: FC<{
           className={clsx('h-4 w-4 shrink-0 transition-transform duration-300', expanded && 'transform rotate-180')}
         />
         {pending && <CircularProgress disableShrink className="absolute right-1 top-1 !h-3 !w-3" />}
-      </ButtonBase>
+      </Button>
     )
   }
 

--- a/apps/web/src/components/sheet/SheetSortFilter.tsx
+++ b/apps/web/src/components/sheet/SheetSortFilter.tsx
@@ -325,7 +325,7 @@ export const SheetSortFilterTrigger: FC<{
     return (
       <ButtonBase
         className={clsx(
-          'relative min-h-[56px] w-[4.75rem] shrink-0 rounded border px-2 py-1.5 transition-all duration-300',
+          'relative min-h-[56px] w-[6.25rem] shrink-0 rounded-[4px] border px-3 py-1.5 transition-all duration-300',
           'flex items-center justify-center gap-1.5 text-zinc-900 shadow-sm backdrop-blur-sm',
           expanded ? 'border-zinc-500 bg-gray-200' : 'border-zinc-400/70 bg-white/70 hover:bg-white/90',
           className,
@@ -340,6 +340,9 @@ export const SheetSortFilterTrigger: FC<{
           <span className="whitespace-nowrap">{t('sheet:filter.title')}</span>
           <span className="whitespace-nowrap">{t('sheet:sort.title')}</span>
         </span>
+        <MdiChevronDownIcon
+          className={clsx('h-4 w-4 shrink-0 transition-transform duration-300', expanded && 'transform rotate-180')}
+        />
         {pending && <CircularProgress disableShrink className="absolute right-1 top-1 !h-3 !w-3" />}
       </ButtonBase>
     )

--- a/apps/web/src/components/sheet/__tests__/SheetSortFilter.test.tsx
+++ b/apps/web/src/components/sheet/__tests__/SheetSortFilter.test.tsx
@@ -74,12 +74,15 @@ describe('SheetSortFilter', () => {
     expect(trigger.getAttribute('aria-expanded')).toBe('false')
     expect(within(trigger).getByText('Filter')).toBeTruthy()
     expect(within(trigger).getByText('Sort')).toBeTruthy()
-    expect(trigger.querySelector('svg')).toBeTruthy()
+    const icons = trigger.querySelectorAll('svg')
+    expect(icons).toHaveLength(2)
+    expect(icons[1]?.getAttribute('class')).not.toContain('rotate-180')
     expect(screen.queryByText('Reset All')).toBeNull()
 
     fireEvent.click(trigger)
 
     expect(trigger.getAttribute('aria-expanded')).toBe('true')
+    expect(icons[1]?.getAttribute('class')).toContain('rotate-180')
     expect(screen.getByText('Reset All')).toBeTruthy()
     expect(screen.queryByText('Filter & Sort')).toBeNull()
   })

--- a/apps/web/src/components/sheet/__tests__/SheetSortFilter.test.tsx
+++ b/apps/web/src/components/sheet/__tests__/SheetSortFilter.test.tsx
@@ -86,6 +86,7 @@ describe('SheetSortFilter', () => {
     expect(icons[1]?.getAttribute('class')).toContain('rotate-180')
     const panel = document.getElementById(contentId)
     expect(panel).not.toBeNull()
+    expect(panel?.getAttribute('class')).toContain('transition-[opacity,transform,filter]')
     expect(panel?.closest('.MuiCollapse-root')).not.toBeNull()
     expect(screen.getByText('Reset All')).toBeTruthy()
     expect(screen.queryByText('Filter & Sort')).toBeNull()

--- a/apps/web/src/components/sheet/__tests__/SheetSortFilter.test.tsx
+++ b/apps/web/src/components/sheet/__tests__/SheetSortFilter.test.tsx
@@ -84,6 +84,9 @@ describe('SheetSortFilter', () => {
 
     expect(trigger.getAttribute('aria-expanded')).toBe('true')
     expect(icons[1]?.getAttribute('class')).toContain('rotate-180')
+    const panel = document.getElementById(contentId)
+    expect(panel).not.toBeNull()
+    expect(panel?.closest('.MuiCollapse-root')).not.toBeNull()
     expect(screen.getByText('Reset All')).toBeTruthy()
     expect(screen.queryByText('Filter & Sort')).toBeNull()
   })

--- a/apps/web/src/components/sheet/__tests__/SheetSortFilter.test.tsx
+++ b/apps/web/src/components/sheet/__tests__/SheetSortFilter.test.tsx
@@ -1,7 +1,9 @@
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { useState } from 'react'
 import { renderToString } from 'react-dom/server'
-import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { initI18n } from '@/setup/init-i18n'
-import { SheetSortFilter } from '../SheetSortFilter'
+import { SheetSortFilter, SheetSortFilterTrigger } from '../SheetSortFilter'
 
 vi.mock('@hookform/devtools', () => ({
   DevTool: () => null,
@@ -10,6 +12,17 @@ vi.mock('@hookform/devtools', () => ({
 describe('SheetSortFilter', () => {
   beforeAll(() => {
     initI18n()
+  })
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: vi.fn(() => null),
+        removeItem: vi.fn(),
+        setItem: vi.fn(),
+      },
+    })
   })
 
   it('does not read localStorage during render', () => {
@@ -34,5 +47,40 @@ describe('SheetSortFilter', () => {
         value: originalLocalStorage,
       })
     }
+  })
+
+  it('allows a compact external trigger to expand the filter panel', () => {
+    const contentId = 'sheet-sort-filter-content'
+    const Harness = () => {
+      const [expanded, setExpanded] = useState(false)
+
+      return (
+        <>
+          <SheetSortFilterTrigger
+            variant="compact"
+            expanded={expanded}
+            contentId={contentId}
+            onToggle={() => setExpanded((current) => !current)}
+          />
+          <SheetSortFilter expanded={expanded} contentId={contentId} showDefaultTrigger={false} />
+        </>
+      )
+    }
+
+    render(<Harness />)
+
+    const trigger = screen.getByRole('button', { name: 'Filter & Sort' })
+    expect(trigger.getAttribute('aria-controls')).toBe(contentId)
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+    expect(within(trigger).getByText('Filter')).toBeTruthy()
+    expect(within(trigger).getByText('Sort')).toBeTruthy()
+    expect(trigger.querySelector('svg')).toBeTruthy()
+    expect(screen.queryByText('Reset All')).toBeNull()
+
+    fireEvent.click(trigger)
+
+    expect(trigger.getAttribute('aria-expanded')).toBe('true')
+    expect(screen.getByText('Reset All')).toBeTruthy()
+    expect(screen.queryByText('Filter & Sort')).toBeNull()
   })
 })

--- a/apps/web/src/components/sheet/__tests__/SheetSortFilter.test.tsx
+++ b/apps/web/src/components/sheet/__tests__/SheetSortFilter.test.tsx
@@ -70,6 +70,7 @@ describe('SheetSortFilter', () => {
     render(<Harness />)
 
     const trigger = screen.getByRole('button', { name: 'Filter & Sort' })
+    expect(trigger.getAttribute('class')).toContain('MuiButton-root')
     expect(trigger.getAttribute('aria-controls')).toBe(contentId)
     expect(trigger.getAttribute('aria-expanded')).toBe('false')
     expect(within(trigger).getByText('Filter')).toBeTruthy()

--- a/apps/web/src/components/sheet/__tests__/SheetSortFilter.test.tsx
+++ b/apps/web/src/components/sheet/__tests__/SheetSortFilter.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, within } from '@testing-library/react'
-import { useState } from 'react'
+import { act, useState } from 'react'
 import { renderToString } from 'react-dom/server'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { initI18n } from '@/setup/init-i18n'
@@ -89,5 +89,21 @@ describe('SheetSortFilter', () => {
     expect(panel?.closest('.MuiCollapse-root')).not.toBeNull()
     expect(screen.getByText('Reset All')).toBeTruthy()
     expect(screen.queryByText('Filter & Sort')).toBeNull()
+  })
+
+  it('uses latest uncontrolled expansion state for rapid toggles', () => {
+    const onExpandedChange = vi.fn()
+    render(<SheetSortFilter onExpandedChange={onExpandedChange} />)
+
+    const trigger = screen.getByRole('button', { name: 'Filter & Sort' })
+
+    act(() => {
+      trigger.click()
+      trigger.click()
+    })
+
+    expect(onExpandedChange).toHaveBeenNthCalledWith(1, true)
+    expect(onExpandedChange).toHaveBeenNthCalledWith(2, false)
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
   })
 })

--- a/apps/web/src/pages/SheetList.tsx
+++ b/apps/web/src/pages/SheetList.tsx
@@ -3,14 +3,14 @@ import { IconButton, TextField } from '@mui/material'
 import * as Sentry from '@sentry/tanstackstart-react'
 import { getRouteApi, useNavigate } from '@tanstack/react-router'
 import { usePostHog } from 'posthog-js/react'
-import { type FC, useCallback, useEffect, useMemo, useState } from 'react'
+import { type FC, useCallback, useEffect, useId, useMemo, useState, useTransition } from 'react'
 import { useTranslation } from 'react-i18next'
 import IconMdiClose from '~icons/mdi/close'
 import MdiIconInfo from '~icons/mdi/information'
 import { ResponsiveDialog } from '../components/global/ResponsiveDialog'
 import { SheetDialogContent } from '../components/sheet/SheetDialogContent'
 import { SheetListContainer } from '../components/sheet/SheetListContainer'
-import { SheetSortFilter, type SheetSortFilterForm } from '../components/sheet/SheetSortFilter'
+import { SheetSortFilter, SheetSortFilterTrigger, type SheetSortFilterForm } from '../components/sheet/SheetSortFilter'
 import { SheetDetailsContextProvider } from '../models/context/SheetDetailsContext'
 import { useAppContextDXDataVersion } from '../models/context/useAppContext'
 import { type FlattenedSheet, canonicalIdFromParts, useFilteredSheets, useSheets } from '../songs'
@@ -37,6 +37,9 @@ const SheetListInnerContent: FC<{ search: SearchParams }> = ({ search }) => {
   const { data: sheets, isLoading } = useSheets({ acceptsPartialData: true })
   const version = useAppContextDXDataVersion()
   const [sortFilterOptions, setSortFilterOptions] = useState<SheetSortFilterForm | null>(null)
+  const [sortFilterExpanded, setSortFilterExpanded] = useState(false)
+  const [sortFilterPending, startSortFilterTransition] = useTransition()
+  const sortFilterContentId = useId()
   const navigate = useNavigate()
 
   const query = search.q ?? ''
@@ -62,6 +65,12 @@ const SheetListInnerContent: FC<{ search: SearchParams }> = ({ search }) => {
     },
     [navigate],
   )
+
+  const toggleSortFilter = useCallback(() => {
+    startSortFilterTransition(() => {
+      setSortFilterExpanded((current) => !current)
+    })
+  }, [])
 
   const activeSheet = useMemo<FlattenedSheet | null>(() => {
     const { songId, type, difficulty } = search
@@ -228,31 +237,46 @@ const SheetListInnerContent: FC<{ search: SearchParams }> = ({ search }) => {
           {() => activeSheet && <SheetDialogContent sheet={activeSheet} />}
         </ResponsiveDialog>
 
-        <TextField
-          label={t('sheet:search')}
-          variant="outlined"
-          value={inputQuery}
-          fullWidth
-          onChange={(e) => {
-            updateQuery(e.target.value)
-          }}
-          InputProps={{
-            endAdornment: inputQuery && (
-              <IconButton
-                onClick={() => {
-                  updateQuery('')
-                  posthog?.capture('sheet_search_clear_button_clicked')
-                }}
-                size="small"
-              >
-                <IconMdiClose />
-              </IconButton>
-            ),
-          }}
-          data-attr="sheet-search"
-        />
+        <div className="flex w-full items-stretch gap-2">
+          <SheetSortFilterTrigger
+            variant="compact"
+            expanded={sortFilterExpanded}
+            contentId={sortFilterContentId}
+            pending={sortFilterPending}
+            onToggle={toggleSortFilter}
+            className="self-stretch"
+          />
+
+          <TextField
+            className="min-w-0 flex-1"
+            label={t('sheet:search')}
+            variant="outlined"
+            value={inputQuery}
+            fullWidth
+            onChange={(e) => {
+              updateQuery(e.target.value)
+            }}
+            InputProps={{
+              endAdornment: inputQuery && (
+                <IconButton
+                  onClick={() => {
+                    updateQuery('')
+                    posthog?.capture('sheet_search_clear_button_clicked')
+                  }}
+                  size="small"
+                >
+                  <IconMdiClose />
+                </IconButton>
+              ),
+            }}
+            data-attr="sheet-search"
+          />
+        </div>
 
         <SheetSortFilter
+          expanded={sortFilterExpanded}
+          contentId={sortFilterContentId}
+          showDefaultTrigger={false}
           onChange={(v) => {
             setSortFilterOptions(v)
           }}

--- a/apps/web/src/pages/__tests__/SheetList.test.tsx
+++ b/apps/web/src/pages/__tests__/SheetList.test.tsx
@@ -76,6 +76,7 @@ vi.mock('@/components/sheet/SheetListContainer', () => ({
 
 vi.mock('@/components/sheet/SheetSortFilter', () => ({
   SheetSortFilter: () => <div data-testid="sheet-sort-filter" />,
+  SheetSortFilterTrigger: () => <button type="button">Filter Sort</button>,
 }))
 
 describe('SheetList', () => {


### PR DESCRIPTION
## Summary
- Add a compact Filter/Sort trigger using the mdi filter icon.
- Move the trigger beside the search input and render the expandable filter panel below it.
- Cover the controlled external trigger flow with focused tests.

## Tests
- pnpm --filter @gekichumai/dxrating-web exec vitest run src/components/sheet/__tests__/SheetSortFilter.test.tsx src/pages/__tests__/SheetList.test.tsx
- pnpm --filter @gekichumai/dxrating-web build
- pnpm format:check
- pnpm lint