### PR TITLE
Add pending top nav tab spinner

### DIFF
--- a/apps/web/src/components/layout/AppTabs.tsx
+++ b/apps/web/src/components/layout/AppTabs.tsx
@@ -1,0 +1,85 @@
+import { CircularProgress, Tab, Tabs, Tooltip } from '@mui/material'
+import { Link } from '@tanstack/react-router'
+import type { FC, ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import MdiTrendingUpIcon from '~icons/mdi/trending-up'
+import MdiUpdateIcon from '~icons/mdi/update'
+import { APP_TAB_LINKS, CHART_DISCOVERY_NAV_LINKS, type AppTabValue } from '@/routes/-top-nav-links'
+
+interface AppTabsProps {
+  activeTab: AppTabValue | false
+  pendingTab?: AppTabValue | false
+}
+
+interface AppTabContentProps {
+  children: ReactNode
+  pending: boolean
+}
+
+const AppTabContent: FC<AppTabContentProps> = ({ children, pending }) => (
+  <span className="relative inline-flex items-center justify-center">
+    <span aria-hidden={pending ? true : undefined} style={pending ? { visibility: 'hidden' } : undefined}>
+      {children}
+    </span>
+    {pending && (
+      <span className="absolute inset-0 flex items-center justify-center pointer-events-none">
+        <CircularProgress className="!h-5 !w-5" color="inherit" disableShrink size="1.25rem" />
+      </span>
+    )}
+  </span>
+)
+
+export const AppTabs: FC<AppTabsProps> = ({ activeTab, pendingTab = false }) => {
+  const { t } = useTranslation(['root'])
+  const selectedTab = pendingTab || activeTab
+
+  return (
+    <div className="rounded-xl bg-zinc-900/10 !min-h-2.5rem flex items-center overflow-hidden">
+      <Tabs
+        value={selectedTab}
+        classes={{
+          root: '!min-h-2.5rem',
+          indicator: '!h-full !rounded-lg z-0',
+        }}
+      >
+        {APP_TAB_LINKS.map((link) => {
+          const label = t(link.labelKey)
+          const isPendingTab = pendingTab === link.value
+          const isIconOnlyTab = CHART_DISCOVERY_NAV_LINKS.some((chartLink) => chartLink.value === link.value)
+          const Icon =
+            link.value === 'recent' ? MdiUpdateIcon : link.value === 'trending' ? MdiTrendingUpIcon : undefined
+
+          return (
+            <Tab
+              key={link.value}
+              aria-busy={isPendingTab ? true : undefined}
+              aria-label={isIconOnlyTab || isPendingTab ? label : undefined}
+              component={Link}
+              icon={
+                isIconOnlyTab && Icon ? (
+                  <AppTabContent pending={isPendingTab}>
+                    <Tooltip title={label}>
+                      <span className="inline-flex">
+                        <Icon className="text-lg" />
+                      </span>
+                    </Tooltip>
+                  </AppTabContent>
+                ) : undefined
+              }
+              label={isIconOnlyTab ? undefined : <AppTabContent pending={isPendingTab}>{label}</AppTabContent>}
+              to={link.href}
+              viewTransition
+              classes={{
+                selected: '!text-white font-bold text-shadow-md',
+                root: `!rounded-lg transition-colors z-1 !py-0 !min-h-2.5rem !h-2.5rem ${
+                  isIconOnlyTab ? '!min-w-2.5rem !w-2.5rem !px-0' : ''
+                }`,
+              }}
+              value={link.value}
+            />
+          )
+        })}
+      </Tabs>
+    </div>
+  )
+}

--- a/apps/web/src/components/layout/AppTabs.tsx
+++ b/apps/web/src/components/layout/AppTabs.tsx
@@ -13,12 +13,17 @@ interface AppTabsProps {
 
 interface AppTabContentProps {
   children: ReactNode
+  fixedSize?: boolean
   pending: boolean
 }
 
-const AppTabContent: FC<AppTabContentProps> = ({ children, pending }) => (
-  <span className="relative inline-flex items-center justify-center">
-    <span aria-hidden={pending ? true : undefined} style={pending ? { visibility: 'hidden' } : undefined}>
+const AppTabContent: FC<AppTabContentProps> = ({ children, fixedSize = false, pending }) => (
+  <span className={`relative inline-flex items-center justify-center ${fixedSize ? 'h-5 w-5' : ''}`}>
+    <span
+      aria-hidden={pending ? true : undefined}
+      className={`inline-flex items-center justify-center ${fixedSize ? 'h-5 w-5' : ''}`}
+      style={pending ? { visibility: 'hidden' } : undefined}
+    >
       {children}
     </span>
     {pending && (
@@ -57,10 +62,10 @@ export const AppTabs: FC<AppTabsProps> = ({ activeTab, pendingTab = false }) => 
               component={Link}
               icon={
                 isIconOnlyTab && Icon ? (
-                  <AppTabContent pending={isPendingTab}>
+                  <AppTabContent fixedSize pending={isPendingTab}>
                     <Tooltip title={label}>
-                      <span className="inline-flex">
-                        <Icon className="text-lg" />
+                      <span className="inline-flex h-5 w-5 items-center justify-center leading-none">
+                        <Icon className="block text-lg" />
                       </span>
                     </Tooltip>
                   </AppTabContent>

--- a/apps/web/src/components/layout/AppTabs.tsx
+++ b/apps/web/src/components/layout/AppTabs.tsx
@@ -1,15 +1,16 @@
 import { CircularProgress, Tab, Tabs, Tooltip } from '@mui/material'
-import { Link } from '@tanstack/react-router'
-import type { FC, ReactNode } from 'react'
+import { Link, useLocation, useRouterState } from '@tanstack/react-router'
+import { usePostHog } from 'posthog-js/react'
+import { useEffect, type FC, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import MdiTrendingUpIcon from '~icons/mdi/trending-up'
 import MdiUpdateIcon from '~icons/mdi/update'
-import { APP_TAB_LINKS, CHART_DISCOVERY_NAV_LINKS, type AppTabValue } from '@/routes/-top-nav-links'
-
-interface AppTabsProps {
-  activeTab: AppTabValue | false
-  pendingTab?: AppTabValue | false
-}
+import {
+  APP_TAB_LINKS,
+  CHART_DISCOVERY_NAV_LINKS,
+  getActiveAppTabValue,
+  getPendingAppTabValue,
+} from '@/routes/-top-nav-links'
 
 interface AppTabContentProps {
   children: ReactNode
@@ -34,9 +35,21 @@ const AppTabContent: FC<AppTabContentProps> = ({ children, fixedSize = false, pe
   </span>
 )
 
-export const AppTabs: FC<AppTabsProps> = ({ activeTab, pendingTab = false }) => {
+export const AppTabs: FC = () => {
   const { t } = useTranslation(['root'])
+  const location = useLocation()
+  const posthog = usePostHog()
+
+  const activeTab = getActiveAppTabValue(location.pathname)
+  const pendingTab = useRouterState({
+    select: (state) => getPendingAppTabValue(state.isTransitioning, state.location.pathname),
+  })
   const selectedTab = pendingTab || activeTab
+
+  useEffect(() => {
+    if (!activeTab) return
+    posthog?.capture('tab_switched', { tab: activeTab })
+  }, [posthog, activeTab])
 
   return (
     <div className="rounded-xl bg-zinc-900/10 !min-h-2.5rem flex items-center overflow-hidden">

--- a/apps/web/src/components/layout/__tests__/AppTabs.test.tsx
+++ b/apps/web/src/components/layout/__tests__/AppTabs.test.tsx
@@ -59,6 +59,8 @@ describe('AppTabs', () => {
 
     expect(recentTab.getAttribute('aria-selected')).toBe('true')
     expect(recentTab.getAttribute('aria-busy')).toBe('true')
+    expect(recentTab.querySelector('.relative > span')?.className).toContain('inline-flex')
+    expect(recentTab.querySelector('.relative > span')?.className).toContain('h-5')
     expect(within(recentTab).getByRole('progressbar')).toBeTruthy()
   })
 })

--- a/apps/web/src/components/layout/__tests__/AppTabs.test.tsx
+++ b/apps/web/src/components/layout/__tests__/AppTabs.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, within } from '@testing-library/react'
+import i18n from 'i18next'
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { initI18n } from '@/setup/init-i18n'
+import { AppTabs } from '../AppTabs'
+
+vi.mock('@tanstack/react-router', async () => {
+  const React = await import('react')
+
+  return {
+    Link: React.forwardRef<
+      HTMLAnchorElement,
+      React.AnchorHTMLAttributes<HTMLAnchorElement> & { to: string; viewTransition?: boolean }
+    >(({ to, viewTransition: _viewTransition, children, ...props }, ref) => (
+      <a ref={ref} href={to} {...props}>
+        {children}
+      </a>
+    )),
+  }
+})
+
+vi.mock('~icons/mdi/trending-up', () => ({
+  default: ({ className }: { className?: string }) => <svg className={className} />,
+}))
+
+vi.mock('~icons/mdi/update', () => ({
+  default: ({ className }: { className?: string }) => <svg className={className} />,
+}))
+
+describe('AppTabs', () => {
+  beforeAll(() => {
+    initI18n()
+  })
+
+  beforeEach(async () => {
+    await i18n.changeLanguage('en')
+  })
+
+  it('selects the pending destination tab and shows a width-stable loading indicator', () => {
+    render(<AppTabs activeTab="rating" pendingTab="search" />)
+
+    const searchTab = screen.getByRole('tab', { name: 'Search Charts' })
+    const ratingTab = screen.getByRole('tab', { name: 'My Rating' })
+
+    expect(searchTab.getAttribute('aria-selected')).toBe('true')
+    expect(searchTab.getAttribute('aria-busy')).toBe('true')
+    expect(ratingTab.getAttribute('aria-selected')).toBe('false')
+    expect(within(searchTab).getByRole('progressbar')).toBeTruthy()
+
+    const originalLabel = within(searchTab).getByText('Search Charts')
+    expect(originalLabel.getAttribute('aria-hidden')).toBe('true')
+    expect(originalLabel.getAttribute('style')).toContain('visibility: hidden')
+  })
+
+  it('keeps icon-only tabs named while replacing their visible icon with the loading indicator', () => {
+    render(<AppTabs activeTab="trending" pendingTab="recent" />)
+
+    const recentTab = screen.getByRole('tab', { name: 'Recently updated charts' })
+
+    expect(recentTab.getAttribute('aria-selected')).toBe('true')
+    expect(recentTab.getAttribute('aria-busy')).toBe('true')
+    expect(within(recentTab).getByRole('progressbar')).toBeTruthy()
+  })
+})

--- a/apps/web/src/components/layout/__tests__/AppTabs.test.tsx
+++ b/apps/web/src/components/layout/__tests__/AppTabs.test.tsx
@@ -4,6 +4,15 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { initI18n } from '@/setup/init-i18n'
 import { AppTabs } from '../AppTabs'
 
+const { capture, routeLocation, routerState } = vi.hoisted(() => ({
+  capture: vi.fn(),
+  routeLocation: { pathname: '/rating' },
+  routerState: {
+    isTransitioning: false,
+    location: { pathname: '/rating' },
+  },
+}))
+
 vi.mock('@tanstack/react-router', async () => {
   const React = await import('react')
 
@@ -16,8 +25,14 @@ vi.mock('@tanstack/react-router', async () => {
         {children}
       </a>
     )),
+    useLocation: () => routeLocation,
+    useRouterState: ({ select }: { select: (state: typeof routerState) => unknown }) => select(routerState),
   }
 })
+
+vi.mock('posthog-js/react', () => ({
+  usePostHog: () => ({ capture }),
+}))
 
 vi.mock('~icons/mdi/trending-up', () => ({
   default: ({ className }: { className?: string }) => <svg className={className} />,
@@ -34,10 +49,26 @@ describe('AppTabs', () => {
 
   beforeEach(async () => {
     await i18n.changeLanguage('en')
+    capture.mockClear()
+    routeLocation.pathname = '/rating'
+    routerState.isTransitioning = false
+    routerState.location.pathname = '/rating'
+  })
+
+  it('selects the current route tab and captures the selected tab', () => {
+    render(<AppTabs />)
+
+    const ratingTab = screen.getByRole('tab', { name: 'My Rating' })
+
+    expect(ratingTab.getAttribute('aria-selected')).toBe('true')
+    expect(capture).toHaveBeenCalledWith('tab_switched', { tab: 'rating' })
   })
 
   it('selects the pending destination tab and shows a width-stable loading indicator', () => {
-    render(<AppTabs activeTab="rating" pendingTab="search" />)
+    routerState.isTransitioning = true
+    routerState.location.pathname = '/search'
+
+    render(<AppTabs />)
 
     const searchTab = screen.getByRole('tab', { name: 'Search Charts' })
     const ratingTab = screen.getByRole('tab', { name: 'My Rating' })
@@ -53,7 +84,11 @@ describe('AppTabs', () => {
   })
 
   it('keeps icon-only tabs named while replacing their visible icon with the loading indicator', () => {
-    render(<AppTabs activeTab="trending" pendingTab="recent" />)
+    routeLocation.pathname = '/charts/trending'
+    routerState.isTransitioning = true
+    routerState.location.pathname = '/charts/recent'
+
+    render(<AppTabs />)
 
     const recentTab = screen.getByRole('tab', { name: 'Recently updated charts' })
 

--- a/apps/web/src/routes/-top-nav-links.ts
+++ b/apps/web/src/routes/-top-nav-links.ts
@@ -21,10 +21,9 @@ export const APP_TAB_LINKS = [
 ] as const
 
 export type AppTabValue = (typeof APP_TAB_LINKS)[number]['value']
-type RouterNavigationStatus = 'pending' | 'idle'
 
 export const getActiveAppTabValue = (pathname: string): AppTabValue | false =>
   APP_TAB_LINKS.find((link) => link.href === pathname)?.value ?? false
 
-export const getPendingAppTabValue = (status: RouterNavigationStatus, pathname: string): AppTabValue | false =>
-  status === 'pending' ? getActiveAppTabValue(pathname) : false
+export const getPendingAppTabValue = (isTransitioning: boolean, pathname: string): AppTabValue | false =>
+  isTransitioning ? getActiveAppTabValue(pathname) : false

--- a/apps/web/src/routes/-top-nav-links.ts
+++ b/apps/web/src/routes/-top-nav-links.ts
@@ -21,6 +21,10 @@ export const APP_TAB_LINKS = [
 ] as const
 
 export type AppTabValue = (typeof APP_TAB_LINKS)[number]['value']
+type RouterNavigationStatus = 'pending' | 'idle'
 
 export const getActiveAppTabValue = (pathname: string): AppTabValue | false =>
   APP_TAB_LINKS.find((link) => link.href === pathname)?.value ?? false
+
+export const getPendingAppTabValue = (status: RouterNavigationStatus, pathname: string): AppTabValue | false =>
+  status === 'pending' ? getActiveAppTabValue(pathname) : false

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -154,7 +154,7 @@ function RootLayout() {
 
   const tab = getActiveAppTabValue(pathname)
   const pendingTab = useRouterState({
-    select: (state) => getPendingAppTabValue(state.status, state.location.pathname),
+    select: (state) => getPendingAppTabValue(state.isTransitioning, state.location.pathname),
   })
 
   useEffect(() => {

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,5 +1,5 @@
-import { HeadContent, Link, Outlet, Scripts, createRootRoute, useLocation } from '@tanstack/react-router'
-import { CircularProgress, Tab, Tabs, Tooltip } from '@mui/material'
+import { HeadContent, Outlet, Scripts, createRootRoute, useLocation, useRouterState } from '@tanstack/react-router'
+import { CircularProgress } from '@mui/material'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { usePostHog } from 'posthog-js/react'
 import posthog from 'posthog-js'
@@ -7,13 +7,12 @@ import { PostHogProvider } from 'posthog-js/react'
 import { Suspense, useEffect } from 'react'
 import toast from 'react-hot-toast'
 import { useTranslation } from 'react-i18next'
-import MdiTrendingUpIcon from '~icons/mdi/trending-up'
-import MdiUpdateIcon from '~icons/mdi/update'
 import { CustomizedToaster } from '@/components/global/CustomizedToaster'
 import { OverscrollBackgroundFiller } from '@/components/global/OverscrollBackgroundFiller'
 import { SideEffector } from '@/components/global/SideEffector'
 import { WebpSupportedImage } from '@/components/global/WebpSupportedImage'
 import { VersionRegionSwitcher } from '@/components/global/preferences/VersionRegionSwitcher'
+import { AppTabs } from '@/components/layout/AppTabs'
 import { TopBar } from '@/components/layout/TopBar'
 import { VersionCustomizedThemeProvider } from '@/components/layout/VersionCustomizedThemeProvider'
 import { AppContextProvider } from '@/models/context/AppContext'
@@ -22,7 +21,7 @@ import { buildAlternateLinks } from '@/utils/alternateLinks'
 import { buildRootSeoMeta, resolveSeoLocale } from '@/utils/seo'
 import { useVersionTheme } from '@/utils/useVersionTheme'
 import appCss from '@/index.css?url'
-import { APP_TAB_LINKS, CHART_DISCOVERY_NAV_LINKS, getActiveAppTabValue } from './-top-nav-links'
+import { getActiveAppTabValue, getPendingAppTabValue } from './-top-nav-links'
 import 'virtual:uno.css'
 
 const queryClient = new QueryClient()
@@ -144,7 +143,6 @@ export const Route = createRootRoute({
 
 function RootLayout() {
   const versionTheme = useVersionTheme()
-  const { t } = useTranslation(['root'])
   const location = useLocation()
   const posthog = usePostHog()
 
@@ -155,6 +153,9 @@ function RootLayout() {
   const showTabs = !isSongPage && !isPrivacyPolicy
 
   const tab = getActiveAppTabValue(pathname)
+  const pendingTab = useRouterState({
+    select: (state) => getPendingAppTabValue(state.status, state.location.pathname),
+  })
 
   useEffect(() => {
     if (!tab) return
@@ -180,51 +181,7 @@ function RootLayout() {
         }}
       >
         <VersionRegionSwitcher />
-        {showTabs && (
-          <div className="rounded-xl bg-zinc-900/10 !min-h-2.5rem flex items-center overflow-hidden">
-            <Tabs
-              value={tab}
-              classes={{
-                root: '!min-h-2.5rem',
-                indicator: '!h-full !rounded-lg z-0',
-              }}
-            >
-              {APP_TAB_LINKS.map((link) => {
-                const label = t(link.labelKey)
-                const isIconOnlyTab = CHART_DISCOVERY_NAV_LINKS.some((chartLink) => chartLink.value === link.value)
-                const Icon =
-                  link.value === 'recent' ? MdiUpdateIcon : link.value === 'trending' ? MdiTrendingUpIcon : undefined
-
-                return (
-                  <Tab
-                    key={link.value}
-                    aria-label={isIconOnlyTab ? label : undefined}
-                    component={Link}
-                    icon={
-                      isIconOnlyTab && Icon ? (
-                        <Tooltip title={label}>
-                          <span className="inline-flex">
-                            <Icon className="text-lg" />
-                          </span>
-                        </Tooltip>
-                      ) : undefined
-                    }
-                    label={isIconOnlyTab ? undefined : label}
-                    to={link.href}
-                    viewTransition
-                    classes={{
-                      selected: '!text-white font-bold text-shadow-md',
-                      root: `!rounded-lg transition-colors z-1 !py-0 !min-h-2.5rem !h-2.5rem ${
-                        isIconOnlyTab ? '!min-w-2.5rem !w-2.5rem !px-0' : ''
-                      }`,
-                    }}
-                    value={link.value}
-                  />
-                )
-              })}
-            </Tabs>
-          </div>
-        )}
+        {showTabs && <AppTabs activeTab={tab} pendingTab={pendingTab} />}
       </div>
     </>
   )

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,7 +1,6 @@
-import { HeadContent, Outlet, Scripts, createRootRoute, useLocation, useRouterState } from '@tanstack/react-router'
+import { HeadContent, Outlet, Scripts, createRootRoute, useLocation } from '@tanstack/react-router'
 import { CircularProgress } from '@mui/material'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { usePostHog } from 'posthog-js/react'
 import posthog from 'posthog-js'
 import { PostHogProvider } from 'posthog-js/react'
 import { Suspense, useEffect } from 'react'
@@ -21,7 +20,6 @@ import { buildAlternateLinks } from '@/utils/alternateLinks'
 import { buildRootSeoMeta, resolveSeoLocale } from '@/utils/seo'
 import { useVersionTheme } from '@/utils/useVersionTheme'
 import appCss from '@/index.css?url'
-import { getActiveAppTabValue, getPendingAppTabValue } from './-top-nav-links'
 import 'virtual:uno.css'
 
 const queryClient = new QueryClient()
@@ -144,23 +142,12 @@ export const Route = createRootRoute({
 function RootLayout() {
   const versionTheme = useVersionTheme()
   const location = useLocation()
-  const posthog = usePostHog()
 
   const pathname = location.pathname
 
   const isPrivacyPolicy = pathname === '/privacy-policy'
   const isSongPage = pathname.startsWith('/songs/')
   const showTabs = !isSongPage && !isPrivacyPolicy
-
-  const tab = getActiveAppTabValue(pathname)
-  const pendingTab = useRouterState({
-    select: (state) => getPendingAppTabValue(state.isTransitioning, state.location.pathname),
-  })
-
-  useEffect(() => {
-    if (!tab) return
-    posthog?.capture('tab_switched', { tab })
-  }, [posthog, tab])
 
   if (isPrivacyPolicy) return null
 
@@ -181,7 +168,7 @@ function RootLayout() {
         }}
       >
         <VersionRegionSwitcher />
-        {showTabs && <AppTabs activeTab={tab} pendingTab={pendingTab} />}
+        {showTabs && <AppTabs />}
       </div>
     </>
   )

--- a/apps/web/src/routes/__tests__/-top-nav-links.test.ts
+++ b/apps/web/src/routes/__tests__/-top-nav-links.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { APP_TAB_LINKS, CHART_DISCOVERY_NAV_LINKS, getActiveAppTabValue } from '../-top-nav-links'
+import {
+  APP_TAB_LINKS,
+  CHART_DISCOVERY_NAV_LINKS,
+  getActiveAppTabValue,
+  getPendingAppTabValue,
+} from '../-top-nav-links'
 
 describe('top nav links', () => {
   it('exposes crawlable hrefs for app tabs and chart discovery tabs', () => {
@@ -29,5 +34,12 @@ describe('top nav links', () => {
     expect(getActiveAppTabValue('/rating')).toBe('rating')
     expect(getActiveAppTabValue('/charts/recent')).toBe('recent')
     expect(getActiveAppTabValue('/charts/trending')).toBe('trending')
+  })
+
+  it('selects a pending app tab only while router navigation is pending', () => {
+    expect(getPendingAppTabValue('pending', '/search')).toBe('search')
+    expect(getPendingAppTabValue('pending', '/charts/recent')).toBe('recent')
+    expect(getPendingAppTabValue('pending', '/songs/1/dx/master')).toBe(false)
+    expect(getPendingAppTabValue('idle', '/search')).toBe(false)
   })
 })

--- a/apps/web/src/routes/__tests__/-top-nav-links.test.ts
+++ b/apps/web/src/routes/__tests__/-top-nav-links.test.ts
@@ -36,10 +36,10 @@ describe('top nav links', () => {
     expect(getActiveAppTabValue('/charts/trending')).toBe('trending')
   })
 
-  it('selects a pending app tab only while router navigation is pending', () => {
-    expect(getPendingAppTabValue('pending', '/search')).toBe('search')
-    expect(getPendingAppTabValue('pending', '/charts/recent')).toBe('recent')
-    expect(getPendingAppTabValue('pending', '/songs/1/dx/master')).toBe(false)
-    expect(getPendingAppTabValue('idle', '/search')).toBe(false)
+  it('selects a pending app tab only while router navigation is transitioning', () => {
+    expect(getPendingAppTabValue(true, '/search')).toBe('search')
+    expect(getPendingAppTabValue(true, '/charts/recent')).toBe('recent')
+    expect(getPendingAppTabValue(true, '/songs/1/dx/master')).toBe(false)
+    expect(getPendingAppTabValue(false, '/search')).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- Extract the root top navigation tabs into `AppTabs`.
- Use TanStack Router pending state to select the destination tab while navigation is loading.
- Render a `CircularProgress disableShrink` over the original tab content while keeping the hidden label/icon in-flow so tab width stays stable.
- Add tests for pending text and icon-only tabs.

## Verification
- `pnpm vitest run src/components/layout/__tests__/AppTabs.test.tsx src/routes/__tests__/-top-nav-links.test.ts`
- `pnpm --filter @gekichumai/dxrating-web build`
- `pnpm format:check`
- `pnpm lint` (exits 0 with existing unrelated warnings)