### PR TITLE
Fix partial song URL redirects

### DIFF
--- a/apps/web/src/routes/__tests__/-legacy-song-redirect.test.ts
+++ b/apps/web/src/routes/__tests__/-legacy-song-redirect.test.ts
@@ -58,8 +58,31 @@ describe('resolveLegacySongRouteRedirect', () => {
     expect(resolveLegacySongRouteRedirect(song)).toMatchObject({
       params: {
         songId: 'song-1',
-        type: TypeEnum.DX,
-        difficulty: DifficultyEnum.Basic,
+        type: TypeEnum.STD,
+        difficulty: DifficultyEnum.Master,
+      },
+      statusCode: 308,
+    })
+  })
+
+  it('falls back to the first valid chart when a song has no master chart', () => {
+    const utageOnlySong = {
+      ...song,
+      songId: '[光]BREaK! BREaK! BREaK!',
+      sheets: [
+        {
+          ...song.sheets[0],
+          type: TypeEnum.UTAGE,
+          difficulty: '【光】' as DifficultyEnum,
+        },
+      ],
+    } satisfies Song
+
+    expect(resolveLegacySongRouteRedirect(utageOnlySong)).toMatchObject({
+      params: {
+        songId: '[光]BREaK! BREaK! BREaK!',
+        type: TypeEnum.UTAGE,
+        difficulty: '【光】',
       },
       statusCode: 308,
     })

--- a/apps/web/src/routes/songs_.$songId.tsx
+++ b/apps/web/src/routes/songs_.$songId.tsx
@@ -1,6 +1,5 @@
-import { type Song, TypeEnum, dxdata } from '@gekichumai/dxdata'
+import { DifficultyEnum, type Song, TypeEnum, dxdata } from '@gekichumai/dxdata'
 import { createFileRoute, notFound, redirect } from '@tanstack/react-router'
-import { TYPE_ORDER, getHighestDifficulty } from '@/models/constants'
 
 type SongSearchParams = {
   type?: string
@@ -9,11 +8,25 @@ type SongSearchParams = {
 
 export const LEGACY_SONG_ROUTE_REDIRECT_STATUS_CODE = 308
 
+type SongSheet = Song['sheets'][number]
+
+type SheetRouteParams = {
+  type: TypeEnum
+  difficulty: string
+}
+
+const getSheetRouteParams = (sheet: SongSheet): SheetRouteParams => ({
+  type: sheet.type,
+  difficulty: sheet.difficulty,
+})
+
+const getPreferredSheet = (sheets: SongSheet[]) => {
+  return sheets.find((sheet) => sheet.difficulty === DifficultyEnum.Master) ?? sheets[0]
+}
+
 const getDefaultSheetParams = (song: Song) => {
-  const availableTypes = TYPE_ORDER.filter((type) => song.sheets.some((sheet) => sheet.type === type))
-  const type = availableTypes[0] ?? TypeEnum.DX
-  const difficulty = getHighestDifficulty(song.sheets.filter((sheet) => sheet.type === type))
-  return { type, difficulty }
+  const preferredSheet = getPreferredSheet(song.sheets)
+  return preferredSheet ? getSheetRouteParams(preferredSheet) : { type: TypeEnum.DX, difficulty: DifficultyEnum.Master }
 }
 
 const getLegacySheetParams = (song: Song, requestedType?: string, requestedDifficulty?: string) => {
@@ -21,18 +34,13 @@ const getLegacySheetParams = (song: Song, requestedType?: string, requestedDiffi
     (sheet) => sheet.type === requestedType && sheet.difficulty === requestedDifficulty,
   )
   if (matchingSheet) {
-    return {
-      type: matchingSheet.type,
-      difficulty: matchingSheet.difficulty,
-    }
+    return getSheetRouteParams(matchingSheet)
   }
 
   const requestedTypeSheets = song.sheets.filter((sheet) => sheet.type === requestedType)
-  if (requestedTypeSheets.length > 0) {
-    return {
-      type: requestedType as TypeEnum,
-      difficulty: getHighestDifficulty(requestedTypeSheets),
-    }
+  const preferredRequestedTypeSheet = getPreferredSheet(requestedTypeSheets)
+  if (preferredRequestedTypeSheet) {
+    return getSheetRouteParams(preferredRequestedTypeSheet)
   }
 
   return getDefaultSheetParams(song)


### PR DESCRIPTION
## Summary
- Prefer an existing master chart when resolving partial song URLs.
- Fall back to the first valid sheet when no master chart exists, preserving UTAGE custom difficulty labels.
- Add regression coverage for UTAGE-only partial URL redirects.

## Test Plan
- pnpm exec vitest run src/routes/__tests__/-legacy-song-redirect.test.ts
- pnpm --filter @gekichumai/dxrating-web build
- pnpm lint
- pnpm exec oxfmt --check 'apps/web/src/routes/songs_..tsx' 'apps/web/src/routes/__tests__/-legacy-song-redirect.test.ts'