### PR TITLE
Preserve DXRating.net logo styling

### DIFF
--- a/apps/web/src/components/global/Logo.tsx
+++ b/apps/web/src/components/global/Logo.tsx
@@ -1,9 +1,6 @@
 export const Logo = () => {
   return (
-    <a
-      href="/"
-      className="inline-flex min-h-10 items-center text-lg font-bold leading-none text-black/70 no-underline transition-[color,transform] duration-150 ease-out hover:text-black/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black/60 active:scale-[0.96]"
-    >
+    <a href="/" className="text-lg font-bold text-black/70 leading-none">
       DXRating.net
     </a>
   )

--- a/apps/web/src/components/global/__tests__/Logo.test.tsx
+++ b/apps/web/src/components/global/__tests__/Logo.test.tsx
@@ -6,6 +6,9 @@ describe('Logo', () => {
   it('links the site name back to the home page', () => {
     render(<Logo />)
 
-    expect(screen.getByRole('link', { name: 'DXRating.net' }).getAttribute('href')).toBe('/')
+    const logo = screen.getByRole('link', { name: 'DXRating.net' })
+
+    expect(logo.getAttribute('href')).toBe('/')
+    expect(logo.className).toBe('text-lg font-bold text-black/70 leading-none')
   })
 })


### PR DESCRIPTION
## Summary
- Keep the DXRating.net logo as a home link
- Restore the logo's original visual class so its styling does not change
- Add a regression assertion for the logo class

## Test Plan
- pnpm --filter @gekichumai/dxrating-web exec vitest run src/components/global/__tests__/Logo.test.tsx src/components/global/__tests__/NotFoundContent.test.tsx
- pnpm format:check
- pnpm lint
- pnpm --filter @gekichumai/dxrating-web build