### PR TITLE
Fix top nav loading indicator regression

### DIFF
--- a/apps/web/src/components/layout/AppTabs.tsx
+++ b/apps/web/src/components/layout/AppTabs.tsx
@@ -42,7 +42,8 @@ export const AppTabs: FC = () => {
 
   const activeTab = getActiveAppTabValue(location.pathname)
   const pendingTab = useRouterState({
-    select: (state) => getPendingAppTabValue(state.isTransitioning, state.location.pathname),
+    select: (state) =>
+      getPendingAppTabValue(state.isLoading, state.location.pathname, state.resolvedLocation?.pathname),
   })
   const selectedTab = pendingTab || activeTab
 

--- a/apps/web/src/components/layout/__tests__/AppTabs.test.tsx
+++ b/apps/web/src/components/layout/__tests__/AppTabs.test.tsx
@@ -8,8 +8,10 @@ const { capture, routeLocation, routerState } = vi.hoisted(() => ({
   capture: vi.fn(),
   routeLocation: { pathname: '/rating' },
   routerState: {
+    isLoading: false,
     isTransitioning: false,
     location: { pathname: '/rating' },
+    resolvedLocation: { pathname: '/rating' } as { pathname: string } | undefined,
   },
 }))
 
@@ -51,8 +53,10 @@ describe('AppTabs', () => {
     await i18n.changeLanguage('en')
     capture.mockClear()
     routeLocation.pathname = '/rating'
+    routerState.isLoading = false
     routerState.isTransitioning = false
     routerState.location.pathname = '/rating'
+    routerState.resolvedLocation = { pathname: '/rating' }
   })
 
   it('selects the current route tab and captures the selected tab', () => {
@@ -65,8 +69,9 @@ describe('AppTabs', () => {
   })
 
   it('selects the pending destination tab and shows a width-stable loading indicator', () => {
-    routerState.isTransitioning = true
+    routerState.isLoading = true
     routerState.location.pathname = '/search'
+    routerState.resolvedLocation = { pathname: '/rating' }
 
     render(<AppTabs />)
 
@@ -85,8 +90,9 @@ describe('AppTabs', () => {
 
   it('keeps icon-only tabs named while replacing their visible icon with the loading indicator', () => {
     routeLocation.pathname = '/charts/trending'
-    routerState.isTransitioning = true
+    routerState.isLoading = true
     routerState.location.pathname = '/charts/recent'
+    routerState.resolvedLocation = { pathname: '/charts/trending' }
 
     render(<AppTabs />)
 
@@ -97,5 +103,17 @@ describe('AppTabs', () => {
     expect(recentTab.querySelector('.relative > span')?.className).toContain('inline-flex')
     expect(recentTab.querySelector('.relative > span')?.className).toContain('h-5')
     expect(within(recentTab).getByRole('progressbar')).toBeTruthy()
+  })
+
+  it('does not show a loading indicator for the initial unresolved location', () => {
+    routerState.isLoading = true
+    routerState.resolvedLocation = undefined
+
+    render(<AppTabs />)
+
+    const ratingTab = screen.getByRole('tab', { name: 'My Rating' })
+
+    expect(ratingTab.getAttribute('aria-selected')).toBe('true')
+    expect(screen.queryByRole('progressbar')).toBeNull()
   })
 })

--- a/apps/web/src/routes/-top-nav-links.ts
+++ b/apps/web/src/routes/-top-nav-links.ts
@@ -25,5 +25,11 @@ export type AppTabValue = (typeof APP_TAB_LINKS)[number]['value']
 export const getActiveAppTabValue = (pathname: string): AppTabValue | false =>
   APP_TAB_LINKS.find((link) => link.href === pathname)?.value ?? false
 
-export const getPendingAppTabValue = (isTransitioning: boolean, pathname: string): AppTabValue | false =>
-  isTransitioning ? getActiveAppTabValue(pathname) : false
+export const getPendingAppTabValue = (
+  isLoading: boolean,
+  pathname: string,
+  resolvedPathname?: string,
+): AppTabValue | false => {
+  if (!isLoading || !resolvedPathname || pathname === resolvedPathname) return false
+  return getActiveAppTabValue(pathname)
+}

--- a/apps/web/src/routes/__tests__/-top-nav-links.test.ts
+++ b/apps/web/src/routes/__tests__/-top-nav-links.test.ts
@@ -36,10 +36,12 @@ describe('top nav links', () => {
     expect(getActiveAppTabValue('/charts/trending')).toBe('trending')
   })
 
-  it('selects a pending app tab only while router navigation is transitioning', () => {
-    expect(getPendingAppTabValue(true, '/search')).toBe('search')
-    expect(getPendingAppTabValue(true, '/charts/recent')).toBe('recent')
-    expect(getPendingAppTabValue(true, '/songs/1/dx/master')).toBe(false)
-    expect(getPendingAppTabValue(false, '/search')).toBe(false)
+  it('selects a pending app tab only while the router loads a different resolved location', () => {
+    expect(getPendingAppTabValue(true, '/search', '/rating')).toBe('search')
+    expect(getPendingAppTabValue(true, '/charts/recent', '/charts/trending')).toBe('recent')
+    expect(getPendingAppTabValue(true, '/songs/1/dx/master', '/rating')).toBe(false)
+    expect(getPendingAppTabValue(true, '/search', '/search')).toBe(false)
+    expect(getPendingAppTabValue(true, '/search')).toBe(false)
+    expect(getPendingAppTabValue(false, '/search', '/rating')).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- use router loading plus resolved-location comparison for pending top-nav tabs instead of RouterState.isTransitioning
- keep initial unresolved page loads from showing a tab spinner
- add regression coverage for loading destination tabs and initial unresolved routes

## Verification
- pnpm vitest run src/components/layout/__tests__/AppTabs.test.tsx src/routes/__tests__/-top-nav-links.test.ts
- pnpm --filter @gekichumai/dxrating-web build
- pnpm format:check
- pnpm lint
- git diff --check
- Playwright smoke check: rating -> Search shows aria-busy=true and one progressbar during navigation, then clears after resolve