### PR TITLE
[codex] Fix hydration mismatches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,14 @@ Web requires `apps/web/.env` (no `.env.example` — create manually):
 - **Local DB**: sql.js (SQLite in browser) for offline song data
 - **Analytics**: PostHog + Sentry
 
+### Web SSR and Hydration
+- The web app is server-rendered. SSR-visible markup must be deterministic between the server render and the first client render; do not suppress hydration warnings as a substitute for fixing the mismatch.
+- Request-scoped render inputs such as locale and render time belong in TanStack Start middleware/root route context, then in shared providers such as `RenderEnvironmentProvider`. Do not call `Date.now()`, depend on the browser time zone, or read browser-only state for text that appears in the first hydrated render unless the value is seeded from the server.
+- The root route owns the request-scoped `I18nextProvider`. Server code should create an isolated i18n instance with `createServerI18n(locale)`, while the client uses the shared i18n singleton after hydration has the same initial locale.
+- For sheet release dates and other date-only values rendered in SSR, use the date helpers in `apps/web/src/utils/dateFormatting.ts`. Avoid ad hoc `new Date(...)` plus `toLocaleString()` in components, especially without an explicit `timeZone`.
+- For relative times, use the rendered-at timestamp from `apps/web/src/utils/renderEnvironment.tsx` for the first render and update after mount. This preserves SSR/client parity while keeping the live UI behavior.
+- After SSR-visible web changes, validate at least one non-English locale on a production build or preview and check the browser console for React hydration errors such as React #418.
+
 ### API Layer
 - Contracts are defined with Zod in `apps/backend/src/contract.ts` and **mirrored** in `apps/web/src/lib/contract.ts` — both files must stay in sync.
 - The web client uses `@orpc/openapi-client` + `@orpc/tanstack-query` to call the backend.

--- a/apps/web/src/components/chartDiscovery/recentCharts.ts
+++ b/apps/web/src/components/chartDiscovery/recentCharts.ts
@@ -1,5 +1,6 @@
 import { DifficultyEnum, TypeEnum, dxdata, type Sheet, type Song } from '@gekichumai/dxdata'
 import { buildSheetPath } from '@/components/sheet/sheetLinks'
+import { sheetReleaseDateTimestamp } from '@/utils/dateFormatting'
 
 export const RECENT_CHART_LIMIT = 500
 
@@ -19,14 +20,8 @@ const typeOrder = Object.values(TypeEnum)
 const difficultyOrder = Object.values(DifficultyEnum)
 const excludedRecentChartDifficulties = new Set<string>([DifficultyEnum.Basic, DifficultyEnum.Advanced])
 
-const releaseDateTimestamp = (releaseDate: string | undefined) => {
-  if (!releaseDate) return 0
-  const timestamp = new Date(`${releaseDate}T00:00:00Z`).valueOf()
-  return Number.isFinite(timestamp) ? timestamp : 0
-}
-
 const compareRecentChartLinks = (a: RecentChartLink, b: RecentChartLink) => {
-  const releaseDateComparison = releaseDateTimestamp(b.releaseDate) - releaseDateTimestamp(a.releaseDate)
+  const releaseDateComparison = sheetReleaseDateTimestamp(b.releaseDate) - sheetReleaseDateTimestamp(a.releaseDate)
   if (releaseDateComparison !== 0) return releaseDateComparison
 
   const titleComparison = a.title.localeCompare(b.title)

--- a/apps/web/src/components/chartDiscovery/trendingCharts.ts
+++ b/apps/web/src/components/chartDiscovery/trendingCharts.ts
@@ -2,6 +2,7 @@ import { DifficultyEnum, TypeEnum, dxdata, type Sheet, type Song } from '@gekich
 import { formatSheetIdentity, type SheetIdentity } from '@gekichumai/maimai-domain'
 import { buildSheetPath } from '@/components/sheet/sheetLinks'
 import type { FlattenedSheet } from '@/songs'
+import { sheetReleaseDateTimestamp } from '@/utils/dateFormatting'
 
 export const TRENDING_CHART_LIMIT = 100
 
@@ -48,12 +49,6 @@ const selectRepresentativeSheet = (result: TrendingChartResult, song: Song) => {
   return [...song.sheets].sort(compareRepresentativeSheets)[0] ?? null
 }
 
-const releaseDateTimestamp = (releaseDate: string | undefined) => {
-  if (!releaseDate) return 0
-  const timestamp = new Date(`${releaseDate}T06:00:00+09:00`).valueOf()
-  return Number.isFinite(timestamp) ? timestamp : 0
-}
-
 const toTrendingChartLink = (song: Song, sheet: Sheet): TrendingChartLink => {
   const identity = {
     songId: song.songId,
@@ -70,7 +65,7 @@ const toTrendingChartLink = (song: Song, sheet: Sheet): TrendingChartLink => {
     identity,
     isTypeUtage,
     isRatingEligible: !isTypeUtage,
-    releaseDateTimestamp: releaseDateTimestamp(sheet.releaseDate),
+    releaseDateTimestamp: sheetReleaseDateTimestamp(sheet.releaseDate),
     tags: [],
     href: buildSheetPath(identity),
   }

--- a/apps/web/src/components/sheet/SheetDialogContent.tsx
+++ b/apps/web/src/components/sheet/SheetDialogContent.tsx
@@ -26,7 +26,9 @@ import { apiClient as client } from '../../lib/orpc'
 import { useAuth } from '../../hooks/useAuth'
 import { useAppContextDXDataVersion } from '../../models/context/useAppContext'
 import type { FlattenedSheet } from '../../songs'
+import { formatSheetReleaseDateParts } from '../../utils/dateFormatting'
 import { calculateRating } from '../../utils/rating'
+import { useRenderedAt } from '../../utils/renderEnvironment'
 import { DXRank } from '../global/DXRank'
 import { SheetDialogContentHeader } from './SheetDialogContentHeader'
 import { SheetTitle } from './SheetListItem'
@@ -69,33 +71,20 @@ const SectionHeader: FC<PropsWithChildren<object>> = ({ children }) => (
   </div>
 )
 
-const DAY_MS = 1000 * 60 * 60 * 24
-const RELATIVE_TIME_FORMATS: Record<string, Intl.RelativeTimeFormat> = {
-  en: new Intl.RelativeTimeFormat('en', { numeric: 'auto' }),
-  ja: new Intl.RelativeTimeFormat('ja', { numeric: 'auto' }),
-  'zh-Hans': new Intl.RelativeTimeFormat('zh-Hans', { numeric: 'auto' }),
-  'zh-Hant': new Intl.RelativeTimeFormat('zh-Hant', { numeric: 'auto' }),
-}
-
 const CommentCreatedAt: FC<{ createdAt: string }> = ({ createdAt }) => {
   const formattedDate = useMemo(() => new Date(createdAt).toLocaleString(), [createdAt])
 
   return <div className="text-xs ml-auto">{formattedDate}</div>
 }
 
-const ReleaseDateText: FC<{ releaseDateTimestamp: number }> = ({ releaseDateTimestamp }) => {
+const ReleaseDateText: FC<{ releaseDate: string }> = ({ releaseDate }) => {
   const { t, i18n } = useTranslation(['sheet'])
+  const renderedAt = useRenderedAt()
   const releaseDateText = useMemo(() => {
-    const releaseDate = new Date(releaseDateTimestamp)
-    const relativeTimeFormat = RELATIVE_TIME_FORMATS[i18n.language] ?? RELATIVE_TIME_FORMATS.en
+    const parts = formatSheetReleaseDateParts(releaseDate, i18n.language, renderedAt)
 
-    return t('sheet:release-date', {
-      absoluteDate: releaseDate.toLocaleString(i18n.language, {
-        dateStyle: 'medium',
-      }),
-      relativeDate: relativeTimeFormat.format(Math.floor((releaseDate.getTime() - Date.now()) / DAY_MS), 'day'),
-    })
-  }, [releaseDateTimestamp, i18n.language, t])
+    return t('sheet:release-date', parts)
+  }, [releaseDate, i18n.language, renderedAt, t])
 
   return releaseDateText
 }
@@ -239,9 +228,7 @@ export const SheetDialogContent: FC<SheetDialogContentProps> = memo(({ sheet, cu
       <SheetTitle sheet={sheet} enableAltNames enableClickToCopy className="text-lg font-bold" />
 
       <div className="text-sm -mt-2">
-        <div className="text-zinc-600">
-          {sheet.releaseDate && <ReleaseDateText releaseDateTimestamp={sheet.releaseDateTimestamp} />}
-        </div>
+        <div className="text-zinc-600">{sheet.releaseDate && <ReleaseDateText releaseDate={sheet.releaseDate} />}</div>
       </div>
 
       <div className="flex flex-wrap gap-1">

--- a/apps/web/src/components/song/SongSheetContent.tsx
+++ b/apps/web/src/components/song/SongSheetContent.tsx
@@ -20,7 +20,9 @@ import { apiClient as client } from '../../lib/orpc'
 import { useAuth } from '../../hooks/useAuth'
 import { useAppContextDXDataVersion } from '../../models/context/useAppContext'
 import type { FlattenedSheet } from '../../songs'
+import { formatSheetReleaseDateParts } from '../../utils/dateFormatting'
 import { calculateRating } from '../../utils/rating'
+import { useRenderedAt } from '../../utils/renderEnvironment'
 import { DXRank } from '../global/DXRank'
 import { SheetTags } from '../sheet/tags/SheetTags'
 import { SheetDifficulty } from '../sheet/SheetListItem'
@@ -270,6 +272,7 @@ const Comments: FC<{ sheet: FlattenedSheet }> = ({ sheet }) => {
 export const SongSheetContent: FC<{ sheet: FlattenedSheet; isActive?: boolean }> = memo(
   ({ sheet, isActive = true }) => {
     const { t, i18n } = useTranslation(['sheet', 'global'])
+    const renderedAt = useRenderedAt()
     const ratings = useMemo(
       () =>
         [...PRESET_ACHIEVEMENT_RATES]
@@ -280,7 +283,10 @@ export const SongSheetContent: FC<{ sheet: FlattenedSheet; isActive?: boolean }>
           })),
       [sheet.internalLevelValue],
     )
-    const releaseDate = new Date(sheet.releaseDateTimestamp)
+    const releaseDateParts = useMemo(
+      () => (sheet.releaseDate ? formatSheetReleaseDateParts(sheet.releaseDate, i18n.language, renderedAt) : null),
+      [sheet.releaseDate, i18n.language, renderedAt],
+    )
 
     return (
       <div className="flex flex-col gap-2 relative">
@@ -295,17 +301,7 @@ export const SongSheetContent: FC<{ sheet: FlattenedSheet; isActive?: boolean }>
         </div>
 
         <div className="text-sm">
-          <div className="text-zinc-600">
-            {sheet.releaseDate &&
-              t('sheet:release-date', {
-                absoluteDate: releaseDate.toLocaleString(i18n.language, {
-                  dateStyle: 'medium',
-                }),
-                relativeDate: new Intl.RelativeTimeFormat(i18n.language, {
-                  numeric: 'auto',
-                }).format(Math.floor((releaseDate.getTime() - Date.now()) / (1000 * 60 * 60 * 24)), 'day'),
-              })}
-          </div>
+          <div className="text-zinc-600">{releaseDateParts && t('sheet:release-date', releaseDateParts)}</div>
         </div>
 
         <div className="flex flex-wrap gap-1">

--- a/apps/web/src/pages/SheetList.tsx
+++ b/apps/web/src/pages/SheetList.tsx
@@ -14,6 +14,7 @@ import { SheetSortFilter, SheetSortFilterTrigger, type SheetSortFilterForm } fro
 import { SheetDetailsContextProvider } from '../models/context/SheetDetailsContext'
 import { useAppContextDXDataVersion } from '../models/context/useAppContext'
 import { type FlattenedSheet, canonicalIdFromParts, useFilteredSheets, useSheets } from '../songs'
+import { sheetReleaseDateTimestamp } from '../utils/dateFormatting'
 import { sheetMatchesDifficultyFilter } from './sheetDifficultyFilter'
 
 const searchRouteApi = getRouteApi('/search')
@@ -87,7 +88,7 @@ const SheetListInnerContent: FC<{ search: SearchParams }> = ({ search }) => {
       searchAcronyms: song.searchAcronyms,
       isTypeUtage,
       isRatingEligible: !isTypeUtage,
-      releaseDateTimestamp: sheet.releaseDate ? new Date(`${sheet.releaseDate}T06:00:00+09:00`).valueOf() : 0,
+      releaseDateTimestamp: sheetReleaseDateTimestamp(sheet.releaseDate),
       internalLevelValue: sheet.multiverInternalLevelValue
         ? (sheet.multiverInternalLevelValue[version] ?? sheet.internalLevelValue)
         : sheet.internalLevelValue,

--- a/apps/web/src/pages/SongPage.tsx
+++ b/apps/web/src/pages/SongPage.tsx
@@ -11,6 +11,7 @@ import { type FlattenedSheet, canonicalId, getSearchAcronymsWithServerAliases } 
 import { SongHeader } from '../components/song/SongHeader'
 import { SongSheetContent } from '../components/song/SongSheetContent'
 import { SongSheetTabs } from '../components/song/SongSheetTabs'
+import { sheetReleaseDateTimestamp } from '../utils/dateFormatting'
 import { getVisibleSongPageSheets } from './songPageSheets'
 
 const routeApi = getRouteApi('/songs/$songId/$type/$difficulty')
@@ -49,7 +50,7 @@ export const SongPage: FC = () => {
         isTypeUtage,
         isRatingEligible: !isTypeUtage,
         tags: [],
-        releaseDateTimestamp: sheet.releaseDate ? new Date(`${sheet.releaseDate}T06:00:00+09:00`).valueOf() : 0,
+        releaseDateTimestamp: sheetReleaseDateTimestamp(sheet.releaseDate),
         internalLevelValue: sheet.multiverInternalLevelValue
           ? (sheet.multiverInternalLevelValue[appVersion] ?? sheet.internalLevelValue)
           : sheet.internalLevelValue,

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,11 +1,12 @@
 import { HeadContent, Outlet, Scripts, createRootRoute, useLocation } from '@tanstack/react-router'
 import { CircularProgress } from '@mui/material'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import i18n from 'i18next'
 import posthog from 'posthog-js'
 import { PostHogProvider } from 'posthog-js/react'
-import { Suspense, useEffect } from 'react'
+import { Suspense, useEffect, useMemo } from 'react'
 import toast from 'react-hot-toast'
-import { useTranslation } from 'react-i18next'
+import { I18nextProvider, useTranslation } from 'react-i18next'
 import { CustomizedToaster } from '@/components/global/CustomizedToaster'
 import { NotFoundContent } from '@/components/global/NotFoundContent'
 import { OverscrollBackgroundFiller } from '@/components/global/OverscrollBackgroundFiller'
@@ -17,9 +18,11 @@ import { TopBar } from '@/components/layout/TopBar'
 import { VersionCustomizedThemeProvider } from '@/components/layout/VersionCustomizedThemeProvider'
 import { AppContextProvider } from '@/models/context/AppContext'
 import { RatingCalculatorContextProvider } from '@/models/context/RatingCalculatorContext'
+import { createServerI18n } from '@/setup/init-i18n'
 import { buildAlternateLinks } from '@/utils/alternateLinks'
 import { buildRootSeoMeta, resolveSeoLocale } from '@/utils/seo'
 import { useVersionTheme } from '@/utils/useVersionTheme'
+import { RENDERED_AT_META_NAME, RenderEnvironmentProvider, resolveRenderedAt } from '@/utils/renderEnvironment'
 import appCss from '@/index.css?url'
 import 'virtual:uno.css'
 
@@ -37,6 +40,10 @@ export const Route = createRootRoute({
   notFoundComponent: NotFoundContent,
   beforeLoad: (ctx) => ({
     locale: resolveSeoLocale([
+      { context: (ctx as { serverContext?: unknown }).serverContext },
+      { context: ctx.context },
+    ]),
+    renderedAt: resolveRenderedAt([
       { context: (ctx as { serverContext?: unknown }).serverContext },
       { context: ctx.context },
     ]),
@@ -200,23 +207,30 @@ function OAuthErrorHandler() {
 }
 
 function RootComponent() {
+  const { locale, renderedAt } = Route.useRouteContext()
+  const routeI18n = useMemo(() => (import.meta.env.SSR ? createServerI18n(locale) : i18n), [locale])
+
   return (
-    <RootDocument>
-      <QueryClientProvider client={queryClient}>
-        <AppContextProvider>
-          <VersionCustomizedThemeProvider>
-            <RatingCalculatorContextProvider>
-              <PostHogProvider client={posthog}>
-                <SideEffector />
-                <CustomizedToaster />
-                <OAuthErrorHandler />
-                <AppLayout />
-              </PostHogProvider>
-            </RatingCalculatorContextProvider>
-          </VersionCustomizedThemeProvider>
-        </AppContextProvider>
-      </QueryClientProvider>
-    </RootDocument>
+    <RenderEnvironmentProvider renderedAt={renderedAt}>
+      <I18nextProvider i18n={routeI18n}>
+        <RootDocument>
+          <QueryClientProvider client={queryClient}>
+            <AppContextProvider>
+              <VersionCustomizedThemeProvider>
+                <RatingCalculatorContextProvider>
+                  <PostHogProvider client={posthog}>
+                    <SideEffector />
+                    <CustomizedToaster />
+                    <OAuthErrorHandler />
+                    <AppLayout />
+                  </PostHogProvider>
+                </RatingCalculatorContextProvider>
+              </VersionCustomizedThemeProvider>
+            </AppContextProvider>
+          </QueryClientProvider>
+        </RootDocument>
+      </I18nextProvider>
+    </RenderEnvironmentProvider>
   )
 }
 
@@ -244,12 +258,13 @@ function AppLayout() {
 }
 
 function RootDocument({ children }: { children: React.ReactNode }) {
-  const { locale } = Route.useRouteContext()
+  const { locale, renderedAt } = Route.useRouteContext()
 
   return (
     <html lang={locale}>
       <head>
         <HeadContent />
+        <meta name={RENDERED_AT_META_NAME} content={String(renderedAt)} />
       </head>
       <body>
         {children}

--- a/apps/web/src/server.ts
+++ b/apps/web/src/server.ts
@@ -3,10 +3,8 @@ import { wrapFetchWithSentry } from '@sentry/tanstackstart-react'
 import { StartServer, createStartHandler } from '@tanstack/react-start/server'
 import { renderRouterToStream } from '@tanstack/react-router/ssr/server'
 import { createElement } from 'react'
-import { I18nextProvider } from 'react-i18next'
 import { createServerEntry, type ServerEntry } from '@tanstack/react-start/server-entry'
 import { BUNDLE } from './utils/bundle'
-import { createServerI18n } from './setup/init-i18n'
 import { appendVaryHeader, detectServerLocale } from './setup/locale'
 import { finishServerTimingSpan, setServerTimingHeader, startServerTimingSpan } from './setup/server-timing'
 
@@ -21,7 +19,6 @@ const startHandler = createStartHandler(async ({ request, router, responseHeader
   const ssrTiming = startServerTimingSpan('ssr')
   const setupTiming = startServerTimingSpan('ssr_setup')
   const locale = detectServerLocale(request)
-  const serverI18n = createServerI18n(locale)
 
   responseHeaders.set('Content-Language', locale)
   appendVaryHeader(responseHeaders, 'Cookie')
@@ -32,7 +29,7 @@ const startHandler = createStartHandler(async ({ request, router, responseHeader
     request,
     router,
     responseHeaders,
-    children: createElement(I18nextProvider, { i18n: serverI18n }, createElement(StartServer, { router })),
+    children: createElement(StartServer, { router }),
   })
 
   setServerTimingHeader(response.headers, [setupMetric, finishServerTimingSpan(ssrTiming)])

--- a/apps/web/src/start.ts
+++ b/apps/web/src/start.ts
@@ -5,7 +5,7 @@ import { applySecurityReportHeaders } from './setup/security-headers'
 
 const localeMiddleware = createMiddleware().server(async ({ request, next }) => {
   const locale = detectServerLocale(request)
-  const result = await next({ context: { locale } })
+  const result = await next({ context: { locale, renderedAt: Date.now() } })
 
   result.response.headers.set('Content-Language', locale)
   appendVaryHeader(result.response.headers, 'Cookie')

--- a/apps/web/src/utils/__tests__/dateFormatting.test.ts
+++ b/apps/web/src/utils/__tests__/dateFormatting.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { formatSheetReleaseDateParts, sheetReleaseDateTimestamp } from '../dateFormatting'
+
+const originalTimeZone = process.env.TZ
+
+function withTimeZone<T>(timeZone: string, callback: () => T): T {
+  process.env.TZ = timeZone
+  try {
+    return callback()
+  } finally {
+    process.env.TZ = originalTimeZone
+  }
+}
+
+describe('date formatting', () => {
+  afterEach(() => {
+    process.env.TZ = originalTimeZone
+  })
+
+  it('formats sheet release dates consistently across server and browser time zones', () => {
+    const referenceTime = Date.UTC(2026, 4, 31, 12)
+
+    const serverText = withTimeZone('Asia/Tokyo', () => formatSheetReleaseDateParts('2020-07-30', 'en', referenceTime))
+    const browserText = withTimeZone('America/Los_Angeles', () =>
+      formatSheetReleaseDateParts('2020-07-30', 'en', referenceTime),
+    )
+
+    expect(serverText).toEqual(browserText)
+    expect(serverText.absoluteDate).toBe('Jul 30, 2020')
+  })
+
+  it('parses sheet release dates without runtime time zone drift', () => {
+    const serverTimestamp = withTimeZone('Asia/Tokyo', () => sheetReleaseDateTimestamp('2020-07-30'))
+    const browserTimestamp = withTimeZone('America/Los_Angeles', () => sheetReleaseDateTimestamp('2020-07-30'))
+
+    expect(serverTimestamp).toBe(browserTimestamp)
+    expect(new Date(serverTimestamp).toISOString()).toBe('2020-07-30T00:00:00.000Z')
+  })
+})

--- a/apps/web/src/utils/dateFormatting.ts
+++ b/apps/web/src/utils/dateFormatting.ts
@@ -1,0 +1,45 @@
+const DAY_MS = 1000 * 60 * 60 * 24
+const RELEASE_DATE_TIME_ZONE = 'UTC'
+
+const dateFormatters = new Map<string, Intl.DateTimeFormat>()
+const relativeTimeFormatters = new Map<string, Intl.RelativeTimeFormat>()
+
+function getDateFormatter(locale: string) {
+  const cached = dateFormatters.get(locale)
+  if (cached) return cached
+
+  const formatter = new Intl.DateTimeFormat(locale, {
+    dateStyle: 'medium',
+    timeZone: RELEASE_DATE_TIME_ZONE,
+  })
+  dateFormatters.set(locale, formatter)
+  return formatter
+}
+
+function getRelativeTimeFormatter(locale: string) {
+  const cached = relativeTimeFormatters.get(locale)
+  if (cached) return cached
+
+  const formatter = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' })
+  relativeTimeFormatters.set(locale, formatter)
+  return formatter
+}
+
+export function sheetReleaseDateTimestamp(releaseDate: string | undefined) {
+  if (!releaseDate) return 0
+
+  const timestamp = Date.parse(`${releaseDate}T00:00:00.000Z`)
+  return Number.isFinite(timestamp) ? timestamp : 0
+}
+
+export function formatSheetReleaseDateParts(releaseDate: string, locale: string, referenceTime: number) {
+  const timestamp = sheetReleaseDateTimestamp(releaseDate)
+  const referenceTimestamp = Number.isFinite(referenceTime) ? referenceTime : Date.now()
+  const releaseDay = Math.floor(timestamp / DAY_MS)
+  const referenceDay = Math.floor(referenceTimestamp / DAY_MS)
+
+  return {
+    absoluteDate: getDateFormatter(locale).format(new Date(timestamp)),
+    relativeDate: getRelativeTimeFormatter(locale).format(releaseDay - referenceDay, 'day'),
+  }
+}

--- a/apps/web/src/utils/renderEnvironment.tsx
+++ b/apps/web/src/utils/renderEnvironment.tsx
@@ -1,0 +1,48 @@
+import { createContext, type PropsWithChildren, useContext } from 'react'
+
+export const RENDERED_AT_META_NAME = 'dxrating-rendered-at'
+
+type RenderEnvironment = {
+  renderedAt: number
+}
+
+type RouteContextMatch = {
+  context?: unknown
+}
+
+const RenderEnvironmentContext = createContext<RenderEnvironment>({ renderedAt: 0 })
+
+function normalizeRenderedAt(value: unknown) {
+  const timestamp = typeof value === 'string' ? Number(value) : value
+  return typeof timestamp === 'number' && Number.isFinite(timestamp) && timestamp > 0 ? timestamp : null
+}
+
+function readRenderedAtFromContext(context: unknown): number | null {
+  if (typeof context !== 'object' || context === null) return null
+
+  const record = context as Record<string, unknown>
+  return normalizeRenderedAt(record.renderedAt) ?? readRenderedAtFromContext(record.serverContext)
+}
+
+function readRenderedAtFromDocument() {
+  if (typeof document === 'undefined') return null
+
+  return normalizeRenderedAt(document.querySelector(`meta[name="${RENDERED_AT_META_NAME}"]`)?.getAttribute('content'))
+}
+
+export function resolveRenderedAt(matches?: readonly RouteContextMatch[]) {
+  for (const match of [...(matches ?? [])].reverse()) {
+    const renderedAt = readRenderedAtFromContext(match.context)
+    if (renderedAt) return renderedAt
+  }
+
+  return readRenderedAtFromDocument() ?? Date.now()
+}
+
+export function RenderEnvironmentProvider({ renderedAt, children }: PropsWithChildren<RenderEnvironment>) {
+  return <RenderEnvironmentContext.Provider value={{ renderedAt }}>{children}</RenderEnvironmentContext.Provider>
+}
+
+export function useRenderedAt() {
+  return useContext(RenderEnvironmentContext).renderedAt || Date.now()
+}

--- a/apps/web/src/utils/useTime.tsx
+++ b/apps/web/src/utils/useTime.tsx
@@ -1,19 +1,24 @@
 import { intlFormatDistance } from 'date-fns'
 import { memo, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useRenderedAt } from './renderEnvironment'
 
-function useMinuteTick() {
-  const [tick, setTick] = useState(0)
+function useMinuteNow() {
+  const renderedAt = useRenderedAt()
+  const [now, setNow] = useState(renderedAt)
+
   useEffect(() => {
-    const id = setInterval(() => setTick((t) => t + 1), 60_000)
+    setNow(Date.now())
+    const id = setInterval(() => setNow(Date.now()), 60_000)
     return () => clearInterval(id)
   }, [])
-  return tick
+
+  return now
 }
 
 export const useTime = (time?: string, length: 'short' | 'normal' = 'normal') => {
   const { i18n } = useTranslation()
-  const tick = useMinuteTick()
+  const now = useMinuteNow()
   return useMemo(() => {
     try {
       if (!time) throw new Error('useTime: time is undefined')
@@ -24,7 +29,7 @@ export const useTime = (time?: string, length: 'short' | 'normal' = 'normal') =>
       }
 
       const dateString = date.toLocaleString(i18n.language)
-      const relativeTime = intlFormatDistance(date, new Date())
+      const relativeTime = intlFormatDistance(date, new Date(now))
 
       if (length === 'short') {
         return relativeTime
@@ -33,7 +38,7 @@ export const useTime = (time?: string, length: 'short' | 'normal' = 'normal') =>
     } catch {
       return 'unknown'
     }
-  }, [time, i18n.language, tick])
+  }, [time, i18n.language, now])
 }
 
 /** Self-refreshing relative time display. Rerenders only itself once per minute. */


### PR DESCRIPTION
## Summary

- add a request-scoped render environment so SSR and hydration share the same locale and render timestamp
- make sheet release-date parsing and relative-date formatting deterministic across server/browser time zones
- move server i18n ownership into the root route so the app hydrates with the same language used for SSR
- document the SSR/hydration conventions in `AGENTS.md` for future web changes

## Root Cause

React hydration could compare server markup generated with one locale/time/reference clock against client markup generated with another. Date parsing also depended on runtime time zone in several paths, so release dates and relative text could drift between server and browser.

## Validation

- `pnpm --filter @gekichumai/dxrating-web exec vitest run`
- `pnpm format:check`
- `pnpm lint`
- `pnpm --filter @gekichumai/dxrating-web build`
- `pnpm build`
- `pnpm exec turbo run build --force`
- production preview at `http://127.0.0.1:4173/` checked in browser for `/songs/...`, `/search`, `/charts/recent`, and `/charts/trending` with Japanese and Traditional Chinese SSR cases plus mobile viewport; no hydration mismatch, React #418, or hydration warning observed

Local preview still logs expected PostHog CORS and `localhost:3000` API connection errors when the backend is not running; those are unrelated to hydration.