### PR TITLE
Fix API catalog discovery endpoint

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/node'
-import { Hono } from 'hono'
+import { Hono, type Context } from 'hono'
 import { HTTPException } from 'hono/http-exception'
 import { createMiddleware } from 'hono/factory'
 import { cors } from 'hono/cors'
@@ -23,6 +23,53 @@ import { RequestHeadersPlugin, ResponseHeadersPlugin } from '@orpc/server/plugin
 import { onError } from '@orpc/server'
 
 const app = new Hono<EvlogVariables>()
+
+const API_CATALOG_PROFILE_URL = 'https://www.rfc-editor.org/info/rfc9727'
+const API_CATALOG_CONTENT_TYPE = `application/linkset+json; profile="${API_CATALOG_PROFILE_URL}"`
+
+const getFirstHeaderValue = (value: string | undefined) => value?.split(',')[0]?.trim() || undefined
+
+const getRequestOrigin = (c: Context) => {
+  const requestUrl = new URL(c.req.url)
+  const protocol = getFirstHeaderValue(c.req.header('x-forwarded-proto')) ?? requestUrl.protocol.replace(/:$/, '')
+  const host = getFirstHeaderValue(c.req.header('x-forwarded-host')) ?? c.req.header('host') ?? requestUrl.host
+
+  return `${protocol}://${host}`
+}
+
+const buildApiCatalog = (origin: string) => ({
+  linkset: [
+    {
+      anchor: `${origin}/api/v1`,
+      'service-desc': [
+        {
+          href: `${origin}/spec.json`,
+          type: 'application/json',
+        },
+      ],
+      'service-doc': [
+        {
+          href: `${origin}/docs`,
+          type: 'text/html',
+        },
+      ],
+      status: [
+        {
+          href: `${origin}/health`,
+          type: 'application/json',
+        },
+      ],
+    },
+  ],
+})
+
+const setApiCatalogHeaders = (c: Context) => {
+  c.header('Content-Type', API_CATALOG_CONTENT_TYPE)
+  c.header(
+    'Link',
+    `</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"; profile="${API_CATALOG_PROFILE_URL}"`,
+  )
+}
 
 // Error handler
 app.onError((err, c) => {
@@ -77,7 +124,16 @@ app.use(
   '*',
   evlog({
     drain,
-    exclude: ['/health', '/version', '/robots.txt', '/docs', '/spec.json', '/', '/api/v1/monitoring/tunnel'],
+    exclude: [
+      '/health',
+      '/version',
+      '/robots.txt',
+      '/docs',
+      '/spec.json',
+      '/',
+      '/.well-known/api-catalog',
+      '/api/v1/monitoring/tunnel',
+    ],
   }) as unknown as MiddlewareHandler,
 )
 
@@ -96,6 +152,17 @@ app.get('/', (c) => c.redirect('/docs'))
 
 // Health endpoint
 app.get('/health', (c) => c.json({ status: 'ok' }))
+
+// API catalog for automated API discovery (RFC 9727)
+app.get('/.well-known/api-catalog', (c) => {
+  setApiCatalogHeaders(c)
+  return c.body(JSON.stringify(buildApiCatalog(getRequestOrigin(c))), 200)
+})
+
+app.on('HEAD', '/.well-known/api-catalog', (c) => {
+  setApiCatalogHeaders(c)
+  return c.body(null, 200)
+})
 
 // Build provenance endpoint
 app.get('/version', async (c) => {

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -29,10 +29,30 @@ const API_CATALOG_CONTENT_TYPE = `application/linkset+json; profile="${API_CATAL
 
 const getFirstHeaderValue = (value: string | undefined) => value?.split(',')[0]?.trim() || undefined
 
+const getValidProtocol = (value: string | undefined) => {
+  const protocol = value?.toLowerCase()
+  return protocol === 'http' || protocol === 'https' ? protocol : undefined
+}
+
+const isValidHost = (host: string | undefined) => {
+  if (!host || /[\s/@\\]/.test(host)) return false
+
+  try {
+    const url = new URL(`https://${host}`)
+    return url.hostname.length > 0 && url.pathname === '/' && !url.search && !url.hash
+  } catch {
+    return false
+  }
+}
+
 const getRequestOrigin = (c: Context) => {
   const requestUrl = new URL(c.req.url)
-  const protocol = getFirstHeaderValue(c.req.header('x-forwarded-proto')) ?? requestUrl.protocol.replace(/:$/, '')
-  const host = getFirstHeaderValue(c.req.header('x-forwarded-host')) ?? c.req.header('host') ?? requestUrl.host
+  const forwardedProtocol = getValidProtocol(getFirstHeaderValue(c.req.header('x-forwarded-proto')))
+  const forwardedHost = getFirstHeaderValue(c.req.header('x-forwarded-host'))
+  const hostHeader = getFirstHeaderValue(c.req.header('host'))
+
+  const protocol = forwardedProtocol ?? requestUrl.protocol.replace(/:$/, '')
+  const host = isValidHost(forwardedHost) ? forwardedHost : isValidHost(hostHeader) ? hostHeader : requestUrl.host
 
   return `${protocol}://${host}`
 }
@@ -65,6 +85,7 @@ const buildApiCatalog = (origin: string) => ({
 
 const setApiCatalogHeaders = (c: Context) => {
   c.header('Content-Type', API_CATALOG_CONTENT_TYPE)
+  c.header('Vary', 'Host, X-Forwarded-Host, X-Forwarded-Proto')
   c.header(
     'Link',
     `</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"; profile="${API_CATALOG_PROFILE_URL}"`,

--- a/apps/backend/src/test/health.test.ts
+++ b/apps/backend/src/test/health.test.ts
@@ -1,6 +1,16 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { setupTestServer, teardownTestServer, getBaseUrl } from './setup.js'
 
+const API_CATALOG_PROFILE_URL = 'https://www.rfc-editor.org/info/rfc9727'
+
+const expectApiCatalogContentType = (contentType: string | null) => {
+  expect(contentType).not.toBeNull()
+
+  const [mediaType, ...parameters] = contentType!.split(';').map((value) => value.trim())
+  expect(mediaType).toBe('application/linkset+json')
+  expect(parameters).toContain(`profile="${API_CATALOG_PROFILE_URL}"`)
+}
+
 describe('Health & Basic Endpoints', () => {
   beforeAll(async () => {
     await setupTestServer()
@@ -19,9 +29,10 @@ describe('Health & Basic Endpoints', () => {
   it('GET /.well-known/api-catalog returns RFC 9727 linkset JSON', async () => {
     const res = await fetch(`${getBaseUrl()}/.well-known/api-catalog`)
     expect(res.status).toBe(200)
-    expect(res.headers.get('content-type')).toBe(
-      'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"',
-    )
+    expectApiCatalogContentType(res.headers.get('content-type'))
+    expect(res.headers.get('vary')).toContain('Host')
+    expect(res.headers.get('vary')).toContain('X-Forwarded-Host')
+    expect(res.headers.get('vary')).toContain('X-Forwarded-Proto')
 
     const body = await res.json()
     expect(body).toEqual({
@@ -51,15 +62,42 @@ describe('Health & Basic Endpoints', () => {
     })
   })
 
+  it('GET /.well-known/api-catalog uses valid forwarded origin headers', async () => {
+    const res = await fetch(`${getBaseUrl()}/.well-known/api-catalog`, {
+      headers: {
+        'x-forwarded-proto': 'https',
+        'x-forwarded-host': 'api.example.com',
+      },
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.linkset[0].anchor).toBe('https://api.example.com/api/v1')
+  })
+
+  it('GET /.well-known/api-catalog ignores invalid forwarded origin headers', async () => {
+    const res = await fetch(`${getBaseUrl()}/.well-known/api-catalog`, {
+      headers: {
+        'x-forwarded-proto': 'ftp',
+        'x-forwarded-host': 'bad host/path',
+      },
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.linkset[0].anchor).toBe(`${getBaseUrl()}/api/v1`)
+  })
+
   it('HEAD /.well-known/api-catalog exposes api-catalog link metadata', async () => {
     const res = await fetch(`${getBaseUrl()}/.well-known/api-catalog`, { method: 'HEAD' })
     expect(res.status).toBe(200)
-    expect(res.headers.get('content-type')).toBe(
-      'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"',
-    )
-    expect(res.headers.get('link')).toBe(
-      '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"; profile="https://www.rfc-editor.org/info/rfc9727"',
-    )
+    expectApiCatalogContentType(res.headers.get('content-type'))
+
+    const linkHeader = res.headers.get('link')
+    expect(linkHeader).toContain('</.well-known/api-catalog>')
+    expect(linkHeader).toContain('rel="api-catalog"')
+    expect(linkHeader).toContain('type="application/linkset+json"')
+    expect(linkHeader).toContain(`profile="${API_CATALOG_PROFILE_URL}"`)
   })
 
   it('GET /robots.txt returns 200', async () => {

--- a/apps/backend/src/test/health.test.ts
+++ b/apps/backend/src/test/health.test.ts
@@ -16,6 +16,52 @@ describe('Health & Basic Endpoints', () => {
     expect(body.status).toBe('ok')
   })
 
+  it('GET /.well-known/api-catalog returns RFC 9727 linkset JSON', async () => {
+    const res = await fetch(`${getBaseUrl()}/.well-known/api-catalog`)
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe(
+      'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"',
+    )
+
+    const body = await res.json()
+    expect(body).toEqual({
+      linkset: [
+        {
+          anchor: `${getBaseUrl()}/api/v1`,
+          'service-desc': [
+            {
+              href: `${getBaseUrl()}/spec.json`,
+              type: 'application/json',
+            },
+          ],
+          'service-doc': [
+            {
+              href: `${getBaseUrl()}/docs`,
+              type: 'text/html',
+            },
+          ],
+          status: [
+            {
+              href: `${getBaseUrl()}/health`,
+              type: 'application/json',
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('HEAD /.well-known/api-catalog exposes api-catalog link metadata', async () => {
+    const res = await fetch(`${getBaseUrl()}/.well-known/api-catalog`, { method: 'HEAD' })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe(
+      'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"',
+    )
+    expect(res.headers.get('link')).toBe(
+      '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"; profile="https://www.rfc-editor.org/info/rfc9727"',
+    )
+  })
+
   it('GET /robots.txt returns 200', async () => {
     const res = await fetch(`${getBaseUrl()}/robots.txt`)
     expect(res.status).toBe(200)


### PR DESCRIPTION
## Summary
Automated API discovery now receives a valid RFC 9727 catalog from `/.well-known/api-catalog` instead of failing. The catalog points clients at the public API root, OpenAPI spec, human documentation, and health endpoint using `service-desc`, `service-doc`, and `status` relations.

The endpoint also supports `HEAD` with `rel="api-catalog"` link metadata, and generated URLs respect forwarded host/proto headers for proxy deployments.

## Validation
- `pnpm --filter @gekichumai/backend build`
- `pnpm vitest run src/test/health.test.ts`
- `pnpm --filter @gekichumai/backend lint`
- `pnpm exec oxfmt --check apps/backend/src/app.ts apps/backend/src/test/health.test.ts`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)
