### PR TITLE
Add agent discovery headers

### DIFF
--- a/apps/web/src/routes/[.]well-known/api-catalog.ts
+++ b/apps/web/src/routes/[.]well-known/api-catalog.ts
@@ -1,0 +1,25 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { API_CATALOG_CONTENT_TYPE, buildAgentDiscoveryLinkHeader, buildApiCatalogJson } from '@/setup/agent-discovery'
+
+function buildApiCatalogHeaders() {
+  return {
+    'Content-Type': API_CATALOG_CONTENT_TYPE,
+    'Cache-Control': 'public, max-age=86400',
+    Link: buildAgentDiscoveryLinkHeader(),
+  }
+}
+
+export const Route = createFileRoute('/.well-known/api-catalog')({
+  server: {
+    handlers: {
+      GET: async () =>
+        new Response(buildApiCatalogJson(), {
+          headers: buildApiCatalogHeaders(),
+        }),
+      HEAD: async () =>
+        new Response(null, {
+          headers: buildApiCatalogHeaders(),
+        }),
+    },
+  },
+})

--- a/apps/web/src/routes/__tests__/-robots.test.ts
+++ b/apps/web/src/routes/__tests__/-robots.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildRobotsTxt } from '../robots[.]txt'
+import { CONTENT_SIGNAL_DIRECTIVE, buildRobotsTxt } from '../robots[.]txt'
 
 describe('buildRobotsTxt', () => {
   it('explicitly allows search, user-fetch, and training AI crawlers', () => {
@@ -17,9 +17,11 @@ describe('buildRobotsTxt', () => {
       'Googlebot',
       'Applebot',
     ]) {
-      expect(robots).toContain(`User-agent: ${userAgent}\nAllow: /`)
+      expect(robots).toContain(`User-agent: ${userAgent}\nAllow: /\n${CONTENT_SIGNAL_DIRECTIVE}`)
     }
 
+    expect(robots).toContain(`User-agent: *\nAllow: /\n${CONTENT_SIGNAL_DIRECTIVE}`)
+    expect(robots).toContain('Content-Signal: ai-train=yes, search=yes, ai-input=yes')
     expect(robots).not.toContain('Disallow: /')
     expect(robots).toContain('Sitemap: https://dxrating.net/sitemap.xml')
     expect(robots).toContain('LLM-Info: https://dxrating.net/llms.txt')

--- a/apps/web/src/routes/robots[.]txt.ts
+++ b/apps/web/src/routes/robots[.]txt.ts
@@ -14,8 +14,10 @@ const ALLOWED_USER_AGENTS = [
   '*',
 ]
 
+export const CONTENT_SIGNAL_DIRECTIVE = 'Content-Signal: ai-train=yes, search=yes, ai-input=yes'
+
 export function buildRobotsTxt() {
-  return `${ALLOWED_USER_AGENTS.map((userAgent) => `User-agent: ${userAgent}\nAllow: /`).join('\n\n')}
+  return `${ALLOWED_USER_AGENTS.map((userAgent) => `User-agent: ${userAgent}\nAllow: /\n${CONTENT_SIGNAL_DIRECTIVE}`).join('\n\n')}
 
 Sitemap: https://dxrating.net/sitemap.xml
 LLM-Info: https://dxrating.net/llms.txt`

--- a/apps/web/src/server.ts
+++ b/apps/web/src/server.ts
@@ -4,6 +4,7 @@ import { StartServer, createStartHandler } from '@tanstack/react-start/server'
 import { renderRouterToStream } from '@tanstack/react-router/ssr/server'
 import { createElement } from 'react'
 import { createServerEntry, type ServerEntry } from '@tanstack/react-start/server-entry'
+import { applyHomepageAgentDiscoveryHeaders } from './setup/agent-discovery'
 import { BUNDLE } from './utils/bundle'
 import { appendVaryHeader, detectServerLocale } from './setup/locale'
 import { finishServerTimingSpan, setServerTimingHeader, startServerTimingSpan } from './setup/server-timing'
@@ -23,6 +24,7 @@ const startHandler = createStartHandler(async ({ request, router, responseHeader
   responseHeaders.set('Content-Language', locale)
   appendVaryHeader(responseHeaders, 'Cookie')
   appendVaryHeader(responseHeaders, 'Accept-Language')
+  applyHomepageAgentDiscoveryHeaders(responseHeaders, request)
 
   const setupMetric = finishServerTimingSpan(setupTiming)
   const response = await renderRouterToStream({
@@ -32,6 +34,7 @@ const startHandler = createStartHandler(async ({ request, router, responseHeader
     children: createElement(StartServer, { router }),
   })
 
+  applyHomepageAgentDiscoveryHeaders(response.headers, request)
   setServerTimingHeader(response.headers, [setupMetric, finishServerTimingSpan(ssrTiming)])
 
   return response

--- a/apps/web/src/setup/__tests__/agent-discovery.test.ts
+++ b/apps/web/src/setup/__tests__/agent-discovery.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import {
+  API_CATALOG_CONTENT_TYPE,
+  API_CATALOG_PATH,
+  applyHomepageAgentDiscoveryHeaders,
+  buildAgentDiscoveryLinkHeader,
+  buildApiCatalog,
+  buildApiCatalogJson,
+} from '../agent-discovery'
+
+describe('agent discovery', () => {
+  it('builds registered RFC 8288 Link relations for agent discovery', () => {
+    const linkHeader = buildAgentDiscoveryLinkHeader()
+
+    expect(linkHeader).toContain(`<${API_CATALOG_PATH}>; rel="api-catalog"; type="application/linkset+json"`)
+    expect(linkHeader).toContain(
+      '<https://miruku.dxrating.net/spec.json>; rel="service-desc"; type="application/vnd.oai.openapi+json"',
+    )
+    expect(linkHeader).toContain('<https://miruku.dxrating.net/docs>; rel="service-doc"; type="text/html"')
+    expect(linkHeader).toContain('</llms.txt>; rel="describedby"; type="text/plain"')
+  })
+
+  it('applies Link headers only to homepage responses', () => {
+    const homepageHeaders = new Headers()
+    const searchHeaders = new Headers()
+
+    applyHomepageAgentDiscoveryHeaders(homepageHeaders, new Request('https://dxrating.net/'))
+    applyHomepageAgentDiscoveryHeaders(searchHeaders, new Request('https://dxrating.net/search'))
+
+    expect(homepageHeaders.get('Link')).toBe(buildAgentDiscoveryLinkHeader())
+    expect(searchHeaders.has('Link')).toBe(false)
+  })
+
+  it('does not duplicate existing homepage Link values', () => {
+    const headers = new Headers()
+    const request = new Request('https://dxrating.net/')
+
+    applyHomepageAgentDiscoveryHeaders(headers, request)
+    applyHomepageAgentDiscoveryHeaders(headers, request)
+
+    expect(headers.get('Link')).toBe(buildAgentDiscoveryLinkHeader())
+  })
+
+  it('builds an RFC 9727 linkset API catalog', () => {
+    const catalog = buildApiCatalog()
+
+    expect(API_CATALOG_CONTENT_TYPE).toContain('application/linkset+json')
+    expect(API_CATALOG_CONTENT_TYPE).toContain('https://www.rfc-editor.org/info/rfc9727')
+    expect(catalog.linkset[0]).toEqual({
+      anchor: `https://dxrating.net${API_CATALOG_PATH}`,
+      item: [{ href: 'https://miruku.dxrating.net/api/v1' }],
+    })
+    expect(catalog.linkset[1]).toMatchObject({
+      anchor: 'https://miruku.dxrating.net/api/v1',
+      'service-desc': [{ href: 'https://miruku.dxrating.net/spec.json' }],
+      'service-doc': [{ href: 'https://miruku.dxrating.net/docs' }],
+    })
+    expect(JSON.parse(buildApiCatalogJson())).toEqual(catalog)
+  })
+})

--- a/apps/web/src/setup/__tests__/sentry-start.test.ts
+++ b/apps/web/src/setup/__tests__/sentry-start.test.ts
@@ -6,11 +6,12 @@ describe('TanStack Start Sentry integration', () => {
   it('registers Sentry before local request and function middleware', () => {
     const options = buildStartOptions()
 
-    expect(options.requestMiddleware).toHaveLength(3)
+    expect(options.requestMiddleware).toHaveLength(4)
     expect(options.functionMiddleware).toHaveLength(1)
     expect(options.requestMiddleware[0]).toBe(sentryGlobalRequestMiddleware)
     expect(options.requestMiddleware[1]).not.toBe(sentryGlobalRequestMiddleware)
     expect(options.requestMiddleware[2]).not.toBe(sentryGlobalRequestMiddleware)
+    expect(options.requestMiddleware[3]).not.toBe(sentryGlobalRequestMiddleware)
     expect(options.functionMiddleware[0]).toBe(sentryGlobalFunctionMiddleware)
   })
 })

--- a/apps/web/src/setup/agent-discovery.ts
+++ b/apps/web/src/setup/agent-discovery.ts
@@ -1,0 +1,80 @@
+export const API_CATALOG_PATH = '/.well-known/api-catalog'
+export const API_CATALOG_CONTENT_TYPE =
+  'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"; charset=utf-8'
+
+export const AGENT_DISCOVERY_LINKS = [
+  `<${API_CATALOG_PATH}>; rel="api-catalog"; type="application/linkset+json"`,
+  '<https://miruku.dxrating.net/spec.json>; rel="service-desc"; type="application/vnd.oai.openapi+json"',
+  '<https://miruku.dxrating.net/docs>; rel="service-doc"; type="text/html"',
+  '</llms.txt>; rel="describedby"; type="text/plain"',
+]
+
+export function buildAgentDiscoveryLinkHeader() {
+  return AGENT_DISCOVERY_LINKS.join(', ')
+}
+
+export function isHomepageRequest(request: Request) {
+  return new URL(request.url).pathname === '/'
+}
+
+export function applyHomepageAgentDiscoveryHeaders(headers: Headers, request: Request) {
+  if (!isHomepageRequest(request)) return
+
+  appendLinkHeader(headers, AGENT_DISCOVERY_LINKS)
+}
+
+export function buildApiCatalog() {
+  return {
+    linkset: [
+      {
+        anchor: `https://dxrating.net${API_CATALOG_PATH}`,
+        item: [{ href: 'https://miruku.dxrating.net/api/v1' }],
+      },
+      {
+        anchor: 'https://miruku.dxrating.net/api/v1',
+        'service-desc': [
+          {
+            href: 'https://miruku.dxrating.net/spec.json',
+            type: 'application/vnd.oai.openapi+json',
+          },
+        ],
+        'service-doc': [
+          {
+            href: 'https://miruku.dxrating.net/docs',
+            type: 'text/html',
+          },
+        ],
+        describedby: [
+          {
+            href: 'https://dxrating.net/llms.txt',
+            type: 'text/plain',
+          },
+          {
+            href: 'https://dxrating.net/sitemap.xml',
+            type: 'application/xml',
+          },
+        ],
+        status: [
+          {
+            href: 'https://miruku.dxrating.net/health',
+            type: 'application/json',
+          },
+        ],
+      },
+    ],
+  }
+}
+
+export function buildApiCatalogJson() {
+  return `${JSON.stringify(buildApiCatalog(), null, 2)}\n`
+}
+
+function appendLinkHeader(headers: Headers, links: string[]) {
+  const existingLinkHeader = headers.get('Link') ?? ''
+
+  for (const link of links) {
+    if (!existingLinkHeader.includes(link)) {
+      headers.append('Link', link)
+    }
+  }
+}

--- a/apps/web/src/start.ts
+++ b/apps/web/src/start.ts
@@ -1,5 +1,6 @@
 import { sentryGlobalFunctionMiddleware, sentryGlobalRequestMiddleware } from '@sentry/tanstackstart-react'
 import { createMiddleware, createStart } from '@tanstack/react-start'
+import { applyHomepageAgentDiscoveryHeaders } from './setup/agent-discovery'
 import { appendVaryHeader, detectServerLocale } from './setup/locale'
 import { applySecurityReportHeaders } from './setup/security-headers'
 
@@ -22,9 +23,22 @@ const securityReportHeadersMiddleware = createMiddleware().server(async ({ next 
   return result
 })
 
+const agentDiscoveryHeadersMiddleware = createMiddleware().server(async ({ request, next }) => {
+  const result = await next()
+
+  applyHomepageAgentDiscoveryHeaders(result.response.headers, request)
+
+  return result
+})
+
 export function buildStartOptions() {
   return {
-    requestMiddleware: [sentryGlobalRequestMiddleware, localeMiddleware, securityReportHeadersMiddleware],
+    requestMiddleware: [
+      sentryGlobalRequestMiddleware,
+      localeMiddleware,
+      securityReportHeadersMiddleware,
+      agentDiscoveryHeadersMiddleware,
+    ],
     functionMiddleware: [sentryGlobalFunctionMiddleware],
   }
 }


### PR DESCRIPTION
## Summary

DXRating now advertises agent-discoverable resources from the homepage response, including an RFC 9727 API catalog, the OpenAPI spec, API docs, and LLM info. The new `/.well-known/api-catalog` endpoint serves a Linkset JSON catalog, and `robots.txt` now declares explicit Content Signals for training, search, and AI input usage.

## Test Plan

- `pnpm --filter @gekichumai/dxrating-web exec vitest run src/setup/__tests__/agent-discovery.test.ts src/setup/__tests__/sentry-start.test.ts src/routes/__tests__/-robots.test.ts`
- `pnpm --filter @gekichumai/dxrating-web build`
- `pnpm format:check`
- `pnpm lint` passes with existing unrelated warnings
- Runtime curl checks confirmed `/` returns the new `Link` header, `/robots.txt` includes `Content-Signal`, and `/.well-known/api-catalog` returns `application/linkset+json`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
