### PR TITLE
fix: enable markdown negotiation for agents

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,3 +74,16 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Enable Markdown for Agents
+        run: pnpm --filter @gekichumai/dxrating-web run cf:enable-markdown
+        env:
+          CLOUDFLARE_ZONE_API_TOKEN: ${{ secrets.CLOUDFLARE_ZONE_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          CLOUDFLARE_ZONE_NAME: dxrating.net
+
+      - name: Verify Markdown for Agents
+        run: pnpm --filter @gekichumai/dxrating-web run cf:verify-markdown
+        env:
+          MARKDOWN_FOR_AGENTS_URL: https://dxrating.net/search

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,6 +8,8 @@
     "build": "vite build && tsc --noEmit",
     "preview": "vite preview",
     "deploy": "wrangler deploy",
+    "cf:enable-markdown": "node scripts/cloudflare-markdown-for-agents.mjs enable",
+    "cf:verify-markdown": "node scripts/cloudflare-markdown-for-agents.mjs verify",
     "cf-typegen": "wrangler types",
     "test": "vitest",
     "test:ui": "vitest --ui",

--- a/apps/web/scripts/cloudflare-markdown-for-agents.mjs
+++ b/apps/web/scripts/cloudflare-markdown-for-agents.mjs
@@ -24,7 +24,8 @@ async function cloudflareFetch(path, init = {}) {
 
   const body = await response.json().catch(() => undefined)
   if (!response.ok || body?.success === false) {
-    const message = body?.errors?.map((error) => error.message).join('; ') || response.statusText
+    const errors = Array.isArray(body?.errors) ? body.errors : []
+    const message = errors.map((error) => error.message).join('; ') || response.statusText
     throw new Error(`Cloudflare API request failed: ${message}`)
   }
 

--- a/apps/web/scripts/cloudflare-markdown-for-agents.mjs
+++ b/apps/web/scripts/cloudflare-markdown-for-agents.mjs
@@ -1,0 +1,83 @@
+const API_BASE_URL = 'https://api.cloudflare.com/client/v4'
+const DEFAULT_ZONE_NAME = 'dxrating.net'
+const DEFAULT_VERIFY_URL = 'https://dxrating.net/search'
+
+const command = process.argv[2]
+
+if (!command || !['enable', 'verify'].includes(command)) {
+  console.error('Usage: node scripts/cloudflare-markdown-for-agents.mjs <enable|verify> [url]')
+  process.exit(1)
+}
+
+async function cloudflareFetch(path, init = {}) {
+  const token = process.env.CLOUDFLARE_ZONE_API_TOKEN || process.env.CLOUDFLARE_API_TOKEN
+  if (!token) throw new Error('CLOUDFLARE_ZONE_API_TOKEN or CLOUDFLARE_API_TOKEN is required')
+
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      ...init.headers,
+    },
+  })
+
+  const body = await response.json().catch(() => undefined)
+  if (!response.ok || body?.success === false) {
+    const message = body?.errors?.map((error) => error.message).join('; ') || response.statusText
+    throw new Error(`Cloudflare API request failed: ${message}`)
+  }
+
+  return body
+}
+
+async function resolveZoneId() {
+  if (process.env.CLOUDFLARE_ZONE_ID) return process.env.CLOUDFLARE_ZONE_ID
+
+  const zoneName = process.env.CLOUDFLARE_ZONE_NAME || DEFAULT_ZONE_NAME
+  const body = await cloudflareFetch(`/zones?name=${encodeURIComponent(zoneName)}&status=active`, {
+    method: 'GET',
+    headers: {},
+  })
+  const zoneId = body.result?.[0]?.id
+  if (!zoneId) throw new Error(`No active Cloudflare zone found for ${zoneName}`)
+
+  return zoneId
+}
+
+async function enableMarkdownForAgents() {
+  const zoneId = await resolveZoneId()
+  const body = await cloudflareFetch(`/zones/${zoneId}/settings/content_converter`, {
+    method: 'PATCH',
+    body: JSON.stringify({ value: 'on' }),
+  })
+  const value = body.result?.value
+
+  if (value !== 'on') throw new Error(`Markdown for Agents was not enabled; content_converter=${value ?? 'unknown'}`)
+
+  console.log(`Markdown for Agents enabled for zone ${zoneId}`)
+}
+
+async function verifyMarkdownForAgents() {
+  const url = process.argv[3] || process.env.MARKDOWN_FOR_AGENTS_URL || DEFAULT_VERIFY_URL
+  const response = await fetch(url, { headers: { Accept: 'text/markdown' }, redirect: 'follow' })
+  const contentType = response.headers.get('content-type') || ''
+  const markdownTokens = response.headers.get('x-markdown-tokens')
+
+  if (!response.ok) throw new Error(`Expected 2xx markdown response from ${url}; got ${response.status}`)
+  if (!contentType.toLowerCase().startsWith('text/markdown')) {
+    throw new Error(`Expected Content-Type text/markdown from ${url}; got ${contentType || 'missing'}`)
+  }
+
+  console.log(`Verified ${url}`)
+  console.log(`Content-Type: ${contentType}`)
+  if (markdownTokens) console.log(`x-markdown-tokens: ${markdownTokens}`)
+}
+
+try {
+  if (command === 'enable') await enableMarkdownForAgents()
+  if (command === 'verify') await verifyMarkdownForAgents()
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error)
+  process.exit(1)
+}

--- a/apps/web/src/server.ts
+++ b/apps/web/src/server.ts
@@ -1,19 +1,10 @@
-import * as Sentry from '@sentry/tanstackstart-react'
-import { wrapFetchWithSentry } from '@sentry/tanstackstart-react'
 import { StartServer, createStartHandler } from '@tanstack/react-start/server'
 import { renderRouterToStream } from '@tanstack/react-router/ssr/server'
 import { createElement } from 'react'
 import { createServerEntry, type ServerEntry } from '@tanstack/react-start/server-entry'
-import { BUNDLE } from './utils/bundle'
 import { appendVaryHeader, detectServerLocale } from './setup/locale'
+import { acceptsMarkdown, normalizeMarkdownAcceptForHtmlRender } from './setup/markdownNegotiation'
 import { finishServerTimingSpan, setServerTimingHeader, startServerTimingSpan } from './setup/server-timing'
-
-Sentry.init({
-  dsn: 'https://9346c04036724f129e00a750c8ab9415@o4506648698683392.ingest.us.sentry.io/4511398317064192',
-  release: `dxrating@${BUNDLE.version ?? 'unknown'}`,
-  enabled: import.meta.env.PROD,
-  tracesSampleRate: 0.2,
-})
 
 const startHandler = createStartHandler(async ({ request, router, responseHeaders }) => {
   const ssrTiming = startServerTimingSpan('ssr')
@@ -37,10 +28,19 @@ const startHandler = createStartHandler(async ({ request, router, responseHeader
   return response
 })
 
-const requestHandler: ServerEntry = wrapFetchWithSentry({
+async function handleRequest(request: Request, opts: Parameters<typeof startHandler>[1]) {
+  const shouldVaryOnAccept = acceptsMarkdown(request)
+  const response = await startHandler(normalizeMarkdownAcceptForHtmlRender(request), opts)
+
+  if (shouldVaryOnAccept) appendVaryHeader(response.headers, 'Accept')
+
+  return response
+}
+
+const requestHandler: ServerEntry = {
   fetch(request, opts) {
-    return startHandler(request, opts as Parameters<typeof startHandler>[1])
+    return handleRequest(request, opts as Parameters<typeof startHandler>[1])
   },
-})
+}
 
 export default createServerEntry(requestHandler)

--- a/apps/web/src/setup/__tests__/markdownNegotiation.test.ts
+++ b/apps/web/src/setup/__tests__/markdownNegotiation.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { acceptsMarkdown, normalizeMarkdownAcceptForHtmlRender } from '../markdownNegotiation'
+
+describe('markdown negotiation', () => {
+  it('detects text/markdown in the Accept header', () => {
+    const request = new Request('https://dxrating.net/search', {
+      headers: { Accept: 'application/json;q=0.8, text/markdown; charset=utf-8' },
+    })
+
+    expect(acceptsMarkdown(request)).toBe(true)
+  })
+
+  it('normalizes GET markdown requests to HTML for SSR rendering', () => {
+    const request = new Request('https://dxrating.net/search', {
+      headers: { Accept: 'text/markdown' },
+    })
+
+    const normalized = normalizeMarkdownAcceptForHtmlRender(request)
+
+    expect(normalized.headers.get('Accept')).toContain('text/html')
+  })
+
+  it('does not normalize non-markdown requests', () => {
+    const request = new Request('https://dxrating.net/search', {
+      headers: { Accept: 'text/html' },
+    })
+
+    expect(normalizeMarkdownAcceptForHtmlRender(request)).toBe(request)
+  })
+
+  it('does not normalize non-document methods', () => {
+    const request = new Request('https://dxrating.net/search', {
+      method: 'POST',
+      headers: { Accept: 'text/markdown' },
+    })
+
+    expect(normalizeMarkdownAcceptForHtmlRender(request)).toBe(request)
+  })
+})

--- a/apps/web/src/setup/__tests__/sentry-start.test.ts
+++ b/apps/web/src/setup/__tests__/sentry-start.test.ts
@@ -6,11 +6,10 @@ describe('TanStack Start Sentry integration', () => {
   it('registers Sentry before local request and function middleware', () => {
     const options = buildStartOptions()
 
-    expect(options.requestMiddleware).toHaveLength(3)
+    expect(options.requestMiddleware).toHaveLength(4)
     expect(options.functionMiddleware).toHaveLength(1)
     expect(options.requestMiddleware[0]).toBe(sentryGlobalRequestMiddleware)
-    expect(options.requestMiddleware[1]).not.toBe(sentryGlobalRequestMiddleware)
-    expect(options.requestMiddleware[2]).not.toBe(sentryGlobalRequestMiddleware)
+    expect(options.requestMiddleware.slice(1)).not.toContain(sentryGlobalRequestMiddleware)
     expect(options.functionMiddleware[0]).toBe(sentryGlobalFunctionMiddleware)
   })
 })

--- a/apps/web/src/setup/markdownNegotiation.ts
+++ b/apps/web/src/setup/markdownNegotiation.ts
@@ -1,0 +1,27 @@
+const MARKDOWN_MIME_TYPE = 'text/markdown'
+const HTML_ACCEPT_HEADER = 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
+
+export function acceptsMarkdown(request: Request) {
+  return (
+    request.headers
+      .get('Accept')
+      ?.split(',')
+      .some((value) => value.trim().toLowerCase().split(';')[0] === MARKDOWN_MIME_TYPE)
+    ?? false
+  )
+}
+
+export function normalizeMarkdownAcceptForHtmlRender(request: Request) {
+  if (!acceptsMarkdown(request)) return request
+  if (request.method !== 'GET' && request.method !== 'HEAD') return request
+
+  try {
+    request.headers.set('Accept', HTML_ACCEPT_HEADER)
+    return request
+  } catch {
+    const headers = new Headers(request.headers)
+    headers.set('Accept', HTML_ACCEPT_HEADER)
+
+    return new Request(request, { headers })
+  }
+}

--- a/apps/web/src/start.ts
+++ b/apps/web/src/start.ts
@@ -1,12 +1,11 @@
 import { sentryGlobalFunctionMiddleware, sentryGlobalRequestMiddleware } from '@sentry/tanstackstart-react'
 import { createMiddleware, createStart } from '@tanstack/react-start'
 import { appendVaryHeader, detectServerLocale } from './setup/locale'
-import { acceptsMarkdown, normalizeMarkdownAcceptForHtmlRender } from './setup/markdownNegotiation'
+import { acceptsMarkdown } from './setup/markdownNegotiation'
 import { applySecurityReportHeaders } from './setup/security-headers'
 
 const markdownNegotiationMiddleware = createMiddleware().server(async ({ request, handlerType, next }) => {
   const shouldVaryOnAccept = handlerType === 'router' && acceptsMarkdown(request)
-  if (handlerType === 'router') normalizeMarkdownAcceptForHtmlRender(request)
   const result = await next()
 
   if (shouldVaryOnAccept) appendVaryHeader(result.response.headers, 'Accept')

--- a/apps/web/src/start.ts
+++ b/apps/web/src/start.ts
@@ -1,7 +1,18 @@
 import { sentryGlobalFunctionMiddleware, sentryGlobalRequestMiddleware } from '@sentry/tanstackstart-react'
 import { createMiddleware, createStart } from '@tanstack/react-start'
 import { appendVaryHeader, detectServerLocale } from './setup/locale'
+import { acceptsMarkdown, normalizeMarkdownAcceptForHtmlRender } from './setup/markdownNegotiation'
 import { applySecurityReportHeaders } from './setup/security-headers'
+
+const markdownNegotiationMiddleware = createMiddleware().server(async ({ request, handlerType, next }) => {
+  const shouldVaryOnAccept = handlerType === 'router' && acceptsMarkdown(request)
+  if (handlerType === 'router') normalizeMarkdownAcceptForHtmlRender(request)
+  const result = await next()
+
+  if (shouldVaryOnAccept) appendVaryHeader(result.response.headers, 'Accept')
+
+  return result
+})
 
 const localeMiddleware = createMiddleware().server(async ({ request, next }) => {
   const locale = detectServerLocale(request)
@@ -24,7 +35,7 @@ const securityReportHeadersMiddleware = createMiddleware().server(async ({ next 
 
 export function buildStartOptions() {
   return {
-    requestMiddleware: [sentryGlobalRequestMiddleware, localeMiddleware, securityReportHeadersMiddleware],
+    requestMiddleware: [sentryGlobalRequestMiddleware, markdownNegotiationMiddleware, localeMiddleware, securityReportHeadersMiddleware],
     functionMiddleware: [sentryGlobalFunctionMiddleware],
   }
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -20,7 +20,11 @@ export default defineConfig({
     cloudflare({ viteEnvironment: { name: 'ssr' } }),
     UnoCSS(),
     Icons({ compiler: 'jsx', jsx: 'react', autoInstall: true }),
-    tanstackStart(),
+    tanstackStart({
+      server: {
+        entry: './server.ts',
+      },
+    }),
     viteReact(),
     sentryTanstackStart({
       org: 'gekichumai',

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -4,7 +4,7 @@
   "compatibility_date": "2026-05-13",
   "compatibility_flags": ["nodejs_compat"],
   // Source config for TanStack Start's Cloudflare build. CI deploys the generated dist/server/wrangler.json.
-  "main": "@tanstack/react-start/server-entry",
+  "main": "src/server.ts",
   "workers_dev": true,
   "preview_urls": true,
 }


### PR DESCRIPTION
## Summary

Agents requesting `Accept: text/markdown` no longer hit TanStack Start's HTML-only request guard before Cloudflare can convert the response. Browser requests still render HTML by default, while markdown requests are normalized for origin rendering and marked with `Vary: Accept` so Cloudflare's Markdown for Agents feature can return the converted markdown variant.

The release workflow now enables Cloudflare's `content_converter` zone setting after deployment and verifies that `https://dxrating.net/search` responds to markdown requests with `Content-Type: text/markdown`, logging `x-markdown-tokens` when Cloudflare provides it.

## Testing

- `pnpm --filter @gekichumai/dxrating-web exec vitest run src/setup/__tests__/markdownNegotiation.test.ts`
- `pnpm --filter @gekichumai/dxrating-web build`
- `pnpm lint`
- Local Wrangler header check: `Accept: text/markdown` returned `200 OK` with `Vary: Cookie, Accept-Language, Accept`; plain requests returned `200 OK` HTML with the existing vary headers.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
