### PR TITLE
Add Axiom drain for backend evlog

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -25,3 +25,7 @@ FRONTEND_URL="http://localhost:5173"
 # PostHog (for analytics API queries)
 POSTHOG_PROJECT_ID=""
 POSTHOG_API_KEY=""
+
+# Axiom (for evlog wide events)
+AXIOM_API_KEY=""
+AXIOM_DATASET=""

--- a/apps/backend/.env.production.example
+++ b/apps/backend/.env.production.example
@@ -18,3 +18,7 @@ GITHUB_CLIENT_SECRET=
 
 # Optional: Cloudflare Turnstile (CAPTCHA)
 TURNSTILE_SECRET_KEY=
+
+# Optional: Axiom (for evlog wide events)
+AXIOM_API_KEY=
+AXIOM_DATASET=

--- a/apps/backend/.gitignore
+++ b/apps/backend/.gitignore
@@ -1,2 +1,3 @@
 dist/
+.env
 .env.local

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -37,7 +37,7 @@
     "cookie": "^1.1.1",
     "dotenv": "catalog:",
     "drizzle-orm": "^0.45.2",
-    "evlog": "^2.13.0",
+    "evlog": "^2.18.1",
     "hono": "catalog:",
     "keyv": "^5.6.0",
     "pg": "catalog:",

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -50,6 +50,10 @@ const envSchema = z.object({
   // PostHog (for analytics API queries)
   POSTHOG_PROJECT_ID: optionalString,
   POSTHOG_API_KEY: optionalString,
+
+  // Axiom (for evlog wide events)
+  AXIOM_API_KEY: optionalString,
+  AXIOM_DATASET: optionalString,
 })
 
 export const deriveCrossSubDomainCookieDomain = ({
@@ -106,5 +110,9 @@ export const config = {
   posthog: {
     projectId: env.POSTHOG_PROJECT_ID,
     apiKey: env.POSTHOG_API_KEY,
+  },
+  axiom: {
+    apiKey: env.AXIOM_API_KEY,
+    dataset: env.AXIOM_DATASET,
   },
 } as const

--- a/apps/backend/src/logger.ts
+++ b/apps/backend/src/logger.ts
@@ -1,8 +1,10 @@
-import { initLogger } from 'evlog'
+import { initLogger, type DrainContext, type DrainFn } from 'evlog'
+import { createAxiomDrain } from 'evlog/axiom'
 import { createSentryDrain } from 'evlog/sentry'
 import { config } from './config.js'
 
 const isProduction = config.nodeEnv === 'production'
+const hasAxiomConfig = Boolean(config.axiom.apiKey && config.axiom.dataset)
 
 initLogger({
   env: {
@@ -12,4 +14,24 @@ initLogger({
   pretty: !isProduction,
 })
 
-export const drain = isProduction ? createSentryDrain() : undefined
+const drains: DrainFn[] = []
+
+if (isProduction || hasAxiomConfig) {
+  drains.push(createAxiomDrain())
+}
+
+if (isProduction) {
+  drains.push(createSentryDrain())
+}
+
+export const drain: DrainFn | undefined =
+  drains.length > 0
+    ? async (ctx: DrainContext) => {
+        const results = await Promise.allSettled(drains.map((configuredDrain) => configuredDrain(ctx)))
+        for (const result of results) {
+          if (result.status === 'rejected') {
+            console.error('[evlog] drain failed:', result.reason)
+          }
+        }
+      }
+    : undefined

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,8 +167,8 @@ importers:
         specifier: ^0.45.2
         version: 0.45.2(@cloudflare/workers-types@4.20260508.1)(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.0)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(@types/sql.js@1.4.11)(kysely@0.28.17)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.9)(prisma@7.4.2(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(sql.js@1.14.1)
       evlog:
-        specifier: ^2.13.0
-        version: 2.13.0(@tanstack/start-client-core@1.169.4)(better-auth@1.6.11(923430c5de17614d9f314599b2420e7f))(hono@4.12.14)(ofetch@1.5.1)(react@19.2.6)(vite@8.0.12(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0))
+        specifier: ^2.18.1
+        version: 2.18.1(@orpc/server@1.14.3(@opentelemetry/api@1.9.0)(crossws@0.4.5(srvx@0.11.15))(ws@8.20.0))(@tanstack/start-client-core@1.169.4)(hono@4.12.14)(ofetch@1.5.1)(react@19.2.6)(vite@8.0.12(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0))
       hono:
         specifier: 'catalog:'
         version: 4.12.14
@@ -5305,36 +5305,36 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
-  evlog@2.13.0:
-    resolution: {integrity: sha512-/tpm+MgS7p00O5400b+t7thKgeNBRPj56InQF1+XUloAuZIKtTN1NQlbQq3B+KvnYoBk+Md985sB7HAcJgd0uQ==}
+  evlog@2.18.1:
+    resolution: {integrity: sha512-uP7NNcmgQST0VdJ5c+gm4uBOOQDc/lGDWwH6aRS2H4C6mu4Hm7N8bCi6cSKIz8+If6pD2uA5EgPuhvI7OH+SHA==}
     peerDependencies:
-      '@nestjs/common': '>=11.1.18'
+      '@nestjs/common': '>=11.1.19'
       '@nuxt/kit': ^4.4.2
-      '@tanstack/start-client-core': ^1.167.9
-      ai: '>=6.0.154'
-      better-auth: '>=1.2.0'
+      '@orpc/server': '>=1.14.0'
+      '@tanstack/start-client-core': ^1.167.20
+      ai: '>=6.0.168'
       elysia: '>=1.4.28'
       express: '>=5.2.1'
-      fastify: '>=5.8.4'
+      fastify: '>=5.8.5'
       h3: ^1.15.11
-      hono: ''
-      next: '>=16.2.3'
+      hono: '>=4.11.0'
+      next: '>=16.2.4'
       nitro: ^3.0.260311-beta
       nitropack: ^2.13.3
       ofetch: ^1.5.1
       react: '>=19.2.5'
-      react-router: '>=7.14.0'
+      react-router: '>=7.14.2'
       vite: ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@nestjs/common':
         optional: true
       '@nuxt/kit':
         optional: true
+      '@orpc/server':
+        optional: true
       '@tanstack/start-client-core':
         optional: true
       ai:
-        optional: true
-      better-auth:
         optional: true
       elysia:
         optional: true
@@ -12399,10 +12399,10 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
-  evlog@2.13.0(@tanstack/start-client-core@1.169.4)(better-auth@1.6.11(923430c5de17614d9f314599b2420e7f))(hono@4.12.14)(ofetch@1.5.1)(react@19.2.6)(vite@8.0.12(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)):
+  evlog@2.18.1(@orpc/server@1.14.3(@opentelemetry/api@1.9.0)(crossws@0.4.5(srvx@0.11.15))(ws@8.20.0))(@tanstack/start-client-core@1.169.4)(hono@4.12.14)(ofetch@1.5.1)(react@19.2.6)(vite@8.0.12(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)):
     optionalDependencies:
+      '@orpc/server': 1.14.3(@opentelemetry/api@1.9.0)(crossws@0.4.5(srvx@0.11.15))(ws@8.20.0)
       '@tanstack/start-client-core': 1.169.4
-      better-auth: 1.6.11(923430c5de17614d9f314599b2420e7f)
       hono: 4.12.14
       ofetch: 1.5.1
       react: 19.2.6


### PR DESCRIPTION
## Summary
- Add `evlog/axiom` to the backend logger and compose it with the existing Sentry drain
- Upgrade `evlog` to a version that supports `AXIOM_API_KEY`
- Add Axiom env entries to the backend env examples and parse them in backend config

## Testing
- `pnpm --filter @gekichumai/backend build`
- `pnpm --filter @gekichumai/backend lint`
- `pnpm format:check`
- Verified a local Hono request emits one Axiom ingest call for the expected dataset