### PR TITLE
Fix Utage chart OG image rendering

### DIFF
--- a/apps/backend/src/services/functions/chart-og-image/index.tsx
+++ b/apps/backend/src/services/functions/chart-og-image/index.tsx
@@ -1,5 +1,6 @@
 import { DifficultyEnum, TypeEnum, dxdata } from '@gekichumai/dxdata'
 import type { NoteCounts } from '@gekichumai/dxdata'
+import type { SheetDifficulty } from '@gekichumai/maimai-domain'
 import { ImageResponse } from '@takumi-rs/image-response'
 import type { Handler } from 'hono'
 import { createHash } from 'node:crypto'
@@ -29,6 +30,11 @@ const DIFFICULTY_DISPLAY: Record<DifficultyEnum, DifficultyDisplay> = {
   [DifficultyEnum.ReMaster]: { title: 'Re:MASTER', color: '#ba67f8', textColor: '#ffffff' },
 }
 
+const UTAGE_DIFFICULTY_COLORS = {
+  color: '#ef4444',
+  textColor: '#ffffff',
+} satisfies Pick<DifficultyDisplay, 'color' | 'textColor'>
+
 const TYPE_DISPLAY: Record<TypeEnum, string> = {
   [TypeEnum.DX]: 'DX',
   [TypeEnum.STD]: 'Standard',
@@ -46,7 +52,7 @@ export type ChartOgImageData = {
   detailUrl: string
   type: TypeEnum
   typeLabel: string
-  difficulty: DifficultyEnum
+  difficulty: SheetDifficulty
   difficultyLabel: string
   difficultyColor: string
   difficultyTextColor: string
@@ -85,7 +91,10 @@ export function resolveChartOgImageData(songId: string, type: string, difficulty
   const sheet = song.sheets.find((candidate) => candidate.type === type && candidate.difficulty === difficulty)
   if (!sheet) return null
 
-  const difficultyDisplay = DIFFICULTY_DISPLAY[sheet.difficulty]
+  const sheetDifficulty = sheet.difficulty as SheetDifficulty
+  const difficultyDisplay = resolveDifficultyDisplay(sheet.type, sheetDifficulty)
+  if (!difficultyDisplay) return null
+
   const levelParts = formatInternalLevelLabelParts(sheet.internalLevelValue)
 
   return {
@@ -98,7 +107,7 @@ export function resolveChartOgImageData(songId: string, type: string, difficulty
     detailUrl: buildChartOgDetailUrl(song.songId, sheet.type, sheet.difficulty),
     type: sheet.type,
     typeLabel: TYPE_DISPLAY[sheet.type],
-    difficulty: sheet.difficulty,
+    difficulty: sheetDifficulty,
     difficultyLabel: difficultyDisplay.title,
     difficultyColor: difficultyDisplay.color,
     difficultyTextColor: difficultyDisplay.textColor,
@@ -109,6 +118,24 @@ export function resolveChartOgImageData(songId: string, type: string, difficulty
     noteCounts: sheet.noteCounts,
     version: sheet.version,
   }
+}
+
+function resolveDifficultyDisplay(type: TypeEnum, difficulty: SheetDifficulty): DifficultyDisplay | null {
+  const standardDifficultyDisplay = DIFFICULTY_DISPLAY[difficulty as DifficultyEnum]
+  if (standardDifficultyDisplay) return standardDifficultyDisplay
+
+  if (isUtageType(type)) {
+    return {
+      title: difficulty,
+      ...UTAGE_DIFFICULTY_COLORS,
+    }
+  }
+
+  return null
+}
+
+function isUtageType(type: TypeEnum) {
+  return type === TypeEnum.UTAGE || type === TypeEnum.UTAGE2P
 }
 
 export function createChartOgImageHandler(renderImage: RenderChartOgImage = renderChartOgImage): Handler {

--- a/apps/backend/src/test/chart-og-image.test.ts
+++ b/apps/backend/src/test/chart-og-image.test.ts
@@ -6,6 +6,7 @@ import {
   createChartOgImageHandler,
   formatInternalLevelLabelParts,
   getTitleLayout,
+  resolveChartOgImageData,
 } from '../services/functions/chart-og-image/index.js'
 
 const song = dxdata.songs.find((candidate) =>
@@ -19,6 +20,8 @@ const sheet = song.sheets.find(
 )
 
 if (!sheet) throw new Error('Expected fixture song to include selected sheet')
+
+const utageSongId = '[宴]セガサターン起動音[H.][Remix]'
 
 describe('chart OG image handler', () => {
   it('serves chart images from the API v1 endpoint format', async () => {
@@ -34,6 +37,16 @@ describe('chart OG image handler', () => {
     )
     expect(res.headers.get('etag')).toMatch(/^"sha256-[a-f0-9]{64}"$/)
     expect(res.headers.get('x-content-type-options')).toBe('nosniff')
+    expect((await res.arrayBuffer()).byteLength).toBeGreaterThan(0)
+  })
+
+  it('serves Utage chart images with custom difficulty labels from the API v1 endpoint format', async () => {
+    const res = await app.request(
+      `/api/v1/songs/${encodeURIComponent(utageSongId)}/${TypeEnum.UTAGE}/${encodeURIComponent('【宴】')}/og-image`,
+    )
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('image/png')
     expect((await res.arrayBuffer()).byteLength).toBeGreaterThan(0)
   })
 
@@ -87,6 +100,24 @@ describe('chart OG image handler', () => {
 
     expect(res.status).toBe(404)
     expect(renderImage).not.toHaveBeenCalled()
+  })
+})
+
+describe('chart OG image data resolution', () => {
+  it('supports Utage charts with custom difficulty labels', () => {
+    const data = resolveChartOgImageData(utageSongId, TypeEnum.UTAGE, '【宴】')
+
+    expect(data).toMatchObject({
+      detailUrl: `https://dxrating.net/songs/${encodeURIComponent(utageSongId)}/${TypeEnum.UTAGE}/${encodeURIComponent('【宴】')}`,
+      difficulty: '【宴】',
+      difficultyLabel: '【宴】',
+      level: '13+?',
+      levelLabel: 'Lv 13.6',
+      songId: utageSongId,
+      title: utageSongId,
+      type: TypeEnum.UTAGE,
+      typeLabel: 'Utage',
+    })
   })
 })
 


### PR DESCRIPTION
## Summary
Utage chart OG-image URLs with custom difficulty labels such as `【宴】` now return a PNG instead of failing while resolving chart metadata. The resolver now accepts the catalog's custom Utage difficulty labels and displays that label on the difficulty badge while keeping normal difficulty styling unchanged.

Regression coverage now exercises both the exact Sega Saturn Utage API route and the lower-level chart metadata resolution path.

## Test Plan
- `pnpm --filter @gekichumai/backend test -- src/test/chart-og-image.test.ts`
- `pnpm --filter @gekichumai/backend build`
- `pnpm --filter @gekichumai/backend lint`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
