### PR TITLE
Keep React-managed stylesheets same-origin to prevent Sentry rejections

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -23,6 +23,41 @@
   font-display: swap;
 }
 
+/* Keep route-managed head stylesheets same-origin. React 19 represents newly
+   inserted stylesheet links with promises, so a failed remote stylesheet
+   otherwise surfaces as an unhandled rejection whose value is a DOM Event. */
+@font-face {
+  font-family: 'IBM Plex Mono';
+  src: url('https://fonts.gstatic.com/s/ibmplexmono/v20/-F63fjptAgt5VM-kVkqdyU8n1i8q1w.woff2') format('woff2');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'IBM Plex Mono';
+  src: url('https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3twJwlBFgg.woff2') format('woff2');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'IBM Plex Mono';
+  src: url('https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3vAOwlBFgg.woff2') format('woff2');
+  font-weight: 600;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'IBM Plex Mono';
+  src: url('https://fonts.gstatic.com/s/ibmplexmono/v20/-F6qfjptAgt5VM-kVkqdyU8n3pQPwlBFgg.woff2') format('woff2');
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+}
+
 @font-face {
   font-family: 'Torus';
   src:

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -19,11 +19,10 @@ import { VersionCustomizedThemeProvider } from '@/components/layout/VersionCusto
 import { AppContextProvider } from '@/models/context/AppContext'
 import { RatingCalculatorContextProvider } from '@/models/context/RatingCalculatorContext'
 import { createServerI18n } from '@/setup/init-i18n'
-import { buildAlternateLinks } from '@/utils/alternateLinks'
 import { buildRootSeoMeta, resolveSeoLocale } from '@/utils/seo'
+import { buildRootHeadLinks } from '@/utils/rootHeadLinks'
 import { useVersionTheme } from '@/utils/useVersionTheme'
 import { RENDERED_AT_META_NAME, RenderEnvironmentProvider, resolveRenderedAt } from '@/utils/renderEnvironment'
-import appCss from '@/index.css?url'
 import 'virtual:uno.css'
 
 const queryClient = new QueryClient()
@@ -68,77 +67,10 @@ export const Route = createRootRoute({
           content: 'https://shama.dxrating.net/favicon/pack/v1/browserconfig.xml',
         },
       ],
-      links: [
-        { rel: 'preconnect', href: 'https://shama.dxrating.net' },
-        { rel: 'stylesheet', href: appCss },
-        {
-          rel: 'preload',
-          as: 'font',
-          type: 'font/woff2',
-          href: 'https://shama.dxrating.net/fonts/Torus-Regular.woff2',
-          crossOrigin: 'anonymous',
-        },
-        {
-          rel: 'preload',
-          as: 'font',
-          type: 'font/woff2',
-          href: 'https://shama.dxrating.net/fonts/Torus-SemiBold.woff2',
-          crossOrigin: 'anonymous',
-        },
-        {
-          rel: 'preload',
-          as: 'image',
-          href: 'https://shama.dxrating.net/images/version-logo/circle-plus.webp',
-          fetchPriority: 'high',
-        },
-        ...buildAlternateLinks({
-          pathname: matches[matches.length - 1]?.pathname ?? '/',
-          search: matches[matches.length - 1]?.search,
-        }),
-        { rel: 'preconnect', href: 'https://miruku.dxrating.net' },
-        {
-          rel: 'apple-touch-icon',
-          sizes: '180x180',
-          href: 'https://shama.dxrating.net/favicon/pack/v1/apple-touch-icon.png',
-        },
-        {
-          rel: 'icon',
-          type: 'image/png',
-          sizes: '32x32',
-          href: 'https://shama.dxrating.net/favicon/pack/v1/favicon-32x32.png',
-        },
-        {
-          rel: 'icon',
-          type: 'image/png',
-          sizes: '16x16',
-          href: 'https://shama.dxrating.net/favicon/pack/v1/favicon-16x16.png',
-        },
-        {
-          rel: 'mask-icon',
-          href: 'https://shama.dxrating.net/favicon/pack/v1/safari-pinned-tab.svg',
-          color: '#c8a8f9',
-        },
-        {
-          rel: 'shortcut icon',
-          href: 'https://shama.dxrating.net/favicon/pack/v1/favicon.ico',
-        },
-        {
-          rel: 'search',
-          type: 'application/opensearchdescription+xml',
-          title: 'DXRating Search',
-          href: 'https://dxrating.net/opensearch.xml',
-        },
-        { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
-        {
-          rel: 'preconnect',
-          href: 'https://fonts.gstatic.com',
-          crossOrigin: 'anonymous',
-        },
-        {
-          rel: 'stylesheet',
-          href: 'https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&display=swap',
-        },
-      ],
+      links: buildRootHeadLinks({
+        pathname: matches[matches.length - 1]?.pathname ?? '/',
+        search: matches[matches.length - 1]?.search,
+      }),
     }
   },
   component: RootComponent,

--- a/apps/web/src/setup/__tests__/security-headers.test.ts
+++ b/apps/web/src/setup/__tests__/security-headers.test.ts
@@ -20,6 +20,7 @@ describe('security report headers', () => {
     const headers = buildSecurityReportHeaders()
     const policy = headers['Content-Security-Policy-Report-Only']
     const scriptSources = getDirectiveSources(policy, 'script-src')
+    const styleSources = getDirectiveSources(policy, 'style-src')
     const imageSources = getDirectiveSources(policy, 'img-src')
     const connectSources = getDirectiveSources(policy, 'connect-src')
 
@@ -30,6 +31,7 @@ describe('security report headers', () => {
     expect(policy).toContain("default-src 'self'")
     expect(policy).not.toContain('*.')
     expect(scriptSources).toContain('https://razu.dxrating.net')
+    expect(styleSources).toEqual(["'self'", "'unsafe-inline'"])
     expect(imageSources).toContain('https://gravatar.com')
     expect(imageSources).toContain('https://avatars.githubusercontent.com')
     expect(imageSources).toContain('https://lh3.googleusercontent.com')

--- a/apps/web/src/setup/security-headers.ts
+++ b/apps/web/src/setup/security-headers.ts
@@ -23,7 +23,7 @@ const CSP_DIRECTIVES = [
       'https://sql.js.org',
     ],
   ],
-  ['style-src', ["'self'", "'unsafe-inline'", 'https://fonts.googleapis.com']],
+  ['style-src', ["'self'", "'unsafe-inline'"]],
   ['font-src', ["'self'", 'data:', 'https://fonts.gstatic.com', 'https://shama.dxrating.net']],
   [
     'img-src',

--- a/apps/web/src/utils/__tests__/rootHeadLinks.test.ts
+++ b/apps/web/src/utils/__tests__/rootHeadLinks.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { buildRootHeadLinks } from '../rootHeadLinks'
+
+describe('buildRootHeadLinks', () => {
+  it('keeps React-managed stylesheets same-origin', () => {
+    const links = buildRootHeadLinks({ pathname: '/search', search: { q: '宴' } })
+    const stylesheetLinks = links.filter((link) => link.rel === 'stylesheet')
+
+    expect(stylesheetLinks).toHaveLength(1)
+    expect(stylesheetLinks[0]?.href).not.toMatch(/^https?:\/\//)
+    expect(links).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ href: expect.stringContaining('fonts.googleapis.com') })]),
+    )
+  })
+
+  it('retains the current-route alternate links', () => {
+    const links = buildRootHeadLinks({ pathname: '/search', search: { q: '宴' } })
+
+    expect(links).toContainEqual({
+      rel: 'alternate',
+      hrefLang: 'ja',
+      href: 'https://dxrating.net/search?q=%E5%AE%B4&locale=ja',
+    })
+  })
+})

--- a/apps/web/src/utils/rootHeadLinks.ts
+++ b/apps/web/src/utils/rootHeadLinks.ts
@@ -1,0 +1,74 @@
+import type { JSX } from 'react'
+import { buildAlternateLinks } from '@/utils/alternateLinks'
+import appCss from '@/index.css?url'
+
+type RootHeadLocation = {
+  pathname: string
+  search?: Record<string, unknown>
+}
+
+type HeadLink = JSX.IntrinsicElements['link']
+
+export const buildRootHeadLinks = ({ pathname, search }: RootHeadLocation): HeadLink[] => [
+  { rel: 'preconnect', href: 'https://shama.dxrating.net' },
+  { rel: 'stylesheet', href: appCss },
+  {
+    rel: 'preload',
+    as: 'font',
+    type: 'font/woff2',
+    href: 'https://shama.dxrating.net/fonts/Torus-Regular.woff2',
+    crossOrigin: 'anonymous',
+  },
+  {
+    rel: 'preload',
+    as: 'font',
+    type: 'font/woff2',
+    href: 'https://shama.dxrating.net/fonts/Torus-SemiBold.woff2',
+    crossOrigin: 'anonymous',
+  },
+  {
+    rel: 'preload',
+    as: 'image',
+    href: 'https://shama.dxrating.net/images/version-logo/circle-plus.webp',
+    fetchPriority: 'high',
+  },
+  ...buildAlternateLinks({ pathname, search }),
+  { rel: 'preconnect', href: 'https://miruku.dxrating.net' },
+  {
+    rel: 'apple-touch-icon',
+    sizes: '180x180',
+    href: 'https://shama.dxrating.net/favicon/pack/v1/apple-touch-icon.png',
+  },
+  {
+    rel: 'icon',
+    type: 'image/png',
+    sizes: '32x32',
+    href: 'https://shama.dxrating.net/favicon/pack/v1/favicon-32x32.png',
+  },
+  {
+    rel: 'icon',
+    type: 'image/png',
+    sizes: '16x16',
+    href: 'https://shama.dxrating.net/favicon/pack/v1/favicon-16x16.png',
+  },
+  {
+    rel: 'mask-icon',
+    href: 'https://shama.dxrating.net/favicon/pack/v1/safari-pinned-tab.svg',
+    color: '#c8a8f9',
+  },
+  {
+    rel: 'shortcut icon',
+    href: 'https://shama.dxrating.net/favicon/pack/v1/favicon.ico',
+  },
+  {
+    rel: 'search',
+    type: 'application/opensearchdescription+xml',
+    title: 'DXRating Search',
+    href: 'https://dxrating.net/opensearch.xml',
+  },
+  {
+    rel: 'preconnect',
+    href: 'https://fonts.gstatic.com',
+    crossOrigin: 'anonymous',
+  },
+]


### PR DESCRIPTION
## Summary

- Move root head link construction into a reusable helper.
- Replace the remote Google Fonts stylesheet with local CSS `@font-face` declarations.
- Tighten the style CSP and preserve route-specific alternate links.
- Add regression coverage for same-origin stylesheets and alternate links.

## Testing

- Added Vitest coverage for root head links.
- Updated security header assertions.