### PR TITLE
Fix localized relative time hydration

### DIFF
--- a/apps/web/src/utils/__tests__/useTime.test.tsx
+++ b/apps/web/src/utils/__tests__/useTime.test.tsx
@@ -1,0 +1,38 @@
+import i18n from 'i18next'
+import { render, screen } from '@testing-library/react'
+import { I18nextProvider } from 'react-i18next'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { initI18n } from '@/setup/init-i18n'
+import { RenderEnvironmentProvider } from '../renderEnvironment'
+import { useTime } from '../useTime'
+
+function TimeProbe() {
+  return <span>{useTime('2026-07-18T03:20:00.000Z', 'short')}</span>
+}
+
+describe('useTime', () => {
+  beforeAll(() => {
+    initI18n()
+  })
+
+  afterEach(async () => {
+    vi.useRealTimers()
+    await i18n.changeLanguage('en')
+  })
+
+  it('formats relative time with the active i18n locale', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(Date.parse('2026-07-18T03:40:00.000Z'))
+    await i18n.changeLanguage('zh-Hans')
+
+    render(
+      <I18nextProvider i18n={i18n}>
+        <RenderEnvironmentProvider renderedAt={Date.parse('2026-07-18T03:40:00.000Z')}>
+          <TimeProbe />
+        </RenderEnvironmentProvider>
+      </I18nextProvider>,
+    )
+
+    expect(screen.getByText('20分钟前')).toBeTruthy()
+  })
+})

--- a/apps/web/src/utils/useTime.tsx
+++ b/apps/web/src/utils/useTime.tsx
@@ -29,7 +29,7 @@ export const useTime = (time?: string, length: 'short' | 'normal' = 'normal') =>
       }
 
       const dateString = date.toLocaleString(i18n.language)
-      const relativeTime = intlFormatDistance(date, new Date(now))
+      const relativeTime = intlFormatDistance(date, new Date(now), { locale: i18n.language })
 
       if (length === 'short') {
         return relativeTime


### PR DESCRIPTION
## Summary
- format relative timestamps with the active i18n locale
- add coverage for zh-Hans relative time output during the initial render

## Root Cause
The server-rendered page could output the version timestamp in the runtime default locale, while the client hydrated it with the detected UI locale. For mobile users with non-English locales, this caused a React hydration mismatch after full-page OAuth redirects.

## Tests
- pnpm --filter @gekichumai/dxrating-web test src/utils/__tests__/useTime.test.tsx src/components/layout/__tests__/TopBar.test.tsx
- ./node_modules/.bin/oxlint apps/web/src/utils/useTime.tsx apps/web/src/utils/__tests__/useTime.test.tsx

## Notes
- pnpm --filter @gekichumai/dxrating-web build: Vite client/server builds completed, then local tsc failed on the existing src/server.ts SsrResponse type mismatch (not touched by this PR).
