### PR TITLE
Prevent CPU exhaustion from oversized SSR search queries

### DIFF
--- a/apps/web/src/components/sheet/searchQuerySeed.ts
+++ b/apps/web/src/components/sheet/searchQuerySeed.ts
@@ -3,6 +3,7 @@ import { createSheetsSearchEngine, getFlattenedSheetsForVersion, type FlattenedS
 import { buildSheetPath } from './sheetLinks'
 
 export const SEARCH_QUERY_SEED_LIMIT = 20
+export const SEARCH_QUERY_MAX_LENGTH = 100
 
 export type SearchQuerySeedSheet = Pick<
   FlattenedSheet,
@@ -38,16 +39,28 @@ const toSearchQuerySeedSheet = (sheet: FlattenedSheet): SearchQuerySeedSheet => 
   path: buildSheetPath({ songId: sheet.songId, type: sheet.type, difficulty: sheet.difficulty }),
 })
 
+const searchEngines = new Map<VersionEnum, ReturnType<typeof createSheetsSearchEngine>>()
+
+const getSearchEngine = (version: VersionEnum) => {
+  const cachedSearchEngine = searchEngines.get(version)
+  if (cachedSearchEngine) return cachedSearchEngine
+
+  const searchEngine = createSheetsSearchEngine({
+    songs: dxdata.songs,
+    sheets: getFlattenedSheetsForVersion(version),
+  })
+  searchEngines.set(version, searchEngine)
+  return searchEngine
+}
+
 export const buildSearchQuerySeedSheets = (
   query: string,
   version: VersionEnum = VersionEnum.CiRCLEPLUS,
 ): SearchQuerySeedSheet[] => {
+  if (query.length > SEARCH_QUERY_MAX_LENGTH) {
+    throw new RangeError(`Search query must not exceed ${SEARCH_QUERY_MAX_LENGTH} characters`)
+  }
   if (!query.trim()) return []
 
-  const search = createSheetsSearchEngine({
-    songs: dxdata.songs,
-    sheets: getFlattenedSheetsForVersion(version),
-  })
-
-  return search(query).slice(0, SEARCH_QUERY_SEED_LIMIT).map(toSearchQuerySeedSheet)
+  return getSearchEngine(version)(query).slice(0, SEARCH_QUERY_SEED_LIMIT).map(toSearchQuerySeedSheet)
 }

--- a/apps/web/src/routes/__tests__/-search.test.ts
+++ b/apps/web/src/routes/__tests__/-search.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
-import { Route, loadSearchRouteData } from '../search'
 import { SEARCH_QUERY_MAX_LENGTH } from '@/components/sheet/searchQuerySeed'
+import { Route, loadSearchRouteData, validateSearchParams } from '../search'
 
 vi.mock('@/pages/SheetList', () => ({
   SheetList: () => null,
@@ -21,7 +21,8 @@ describe('/search route', () => {
   it('rejects oversized queries before loading search results', () => {
     const oversizedQuery = 'a'.repeat(SEARCH_QUERY_MAX_LENGTH + 1)
 
-    expect(() => Route.options.validateSearch?.({ q: oversizedQuery } as Record<string, unknown>)).toThrow(RangeError)
+    expect(Route.options.validateSearch).toBe(validateSearchParams)
+    expect(() => validateSearchParams({ q: oversizedQuery })).toThrow(RangeError)
     expect(() => loadSearchRouteData({ q: oversizedQuery })).toThrow(RangeError)
   })
 })

--- a/apps/web/src/routes/__tests__/-search.test.ts
+++ b/apps/web/src/routes/__tests__/-search.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { Route, loadSearchRouteData } from '../search'
+import { SEARCH_QUERY_MAX_LENGTH } from '@/components/sheet/searchQuerySeed'
 
 vi.mock('@/pages/SheetList', () => ({
   SheetList: () => null,
@@ -15,5 +16,12 @@ describe('/search route', () => {
 
     expect(seedSheets.map((sheet) => sheet.title)).toContain('ガラテアの螺旋')
     expect(seedSheets[0]?.path).toMatch(/^\/songs\//)
+  })
+
+  it('rejects oversized queries before loading search results', () => {
+    const oversizedQuery = 'a'.repeat(SEARCH_QUERY_MAX_LENGTH + 1)
+
+    expect(() => Route.options.validateSearch?.({ q: oversizedQuery } as Record<string, unknown>)).toThrow(RangeError)
+    expect(() => loadSearchRouteData({ q: oversizedQuery })).toThrow(RangeError)
   })
 })

--- a/apps/web/src/routes/search.tsx
+++ b/apps/web/src/routes/search.tsx
@@ -1,7 +1,11 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { SheetList } from '@/pages/SheetList'
 import { buildSearchSeo, resolveSeoLocale } from '@/utils/seo'
-import { buildSearchQuerySeedSheets, type SearchQuerySeedSheet } from '@/components/sheet/searchQuerySeed'
+import {
+  buildSearchQuerySeedSheets,
+  SEARCH_QUERY_MAX_LENGTH,
+  type SearchQuerySeedSheet,
+} from '@/components/sheet/searchQuerySeed'
 
 type SearchParams = {
   q?: string
@@ -15,9 +19,17 @@ type SearchLoaderData = {
 }
 
 const searchString = (value: unknown) => {
-  if (typeof value === 'string') return value
-  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
-  return undefined
+  const stringValue =
+    typeof value === 'string'
+      ? value
+      : typeof value === 'number' || typeof value === 'boolean'
+        ? String(value)
+        : undefined
+
+  if (stringValue && stringValue.length > SEARCH_QUERY_MAX_LENGTH) {
+    throw new RangeError(`Search query must not exceed ${SEARCH_QUERY_MAX_LENGTH} characters`)
+  }
+  return stringValue
 }
 
 export const loadSearchRouteData = ({ q }: SearchParams): SearchLoaderData => ({

--- a/apps/web/src/routes/search.tsx
+++ b/apps/web/src/routes/search.tsx
@@ -36,6 +36,13 @@ export const loadSearchRouteData = ({ q }: SearchParams): SearchLoaderData => ({
   seedSheets: q ? buildSearchQuerySeedSheets(q) : [],
 })
 
+export const validateSearchParams = (search: Record<string, unknown>): SearchParams => ({
+  q: searchString(search.q),
+  songId: typeof search.songId === 'string' ? search.songId : undefined,
+  type: typeof search.type === 'string' ? search.type : undefined,
+  difficulty: typeof search.difficulty === 'string' ? search.difficulty : undefined,
+})
+
 export const Route = createFileRoute('/search')({
   ssr: true,
   head: ({ match, matches }) => {
@@ -46,12 +53,7 @@ export const Route = createFileRoute('/search')({
       links: seo.links,
     }
   },
-  validateSearch: (search: Record<string, unknown>): SearchParams => ({
-    q: searchString(search.q),
-    songId: typeof search.songId === 'string' ? search.songId : undefined,
-    type: typeof search.type === 'string' ? search.type : undefined,
-    difficulty: typeof search.difficulty === 'string' ? search.difficulty : undefined,
-  }),
+  validateSearch: validateSearchParams,
   loaderDeps: ({ search }): SearchParams => ({
     q: search.q,
     songId: search.songId,


### PR DESCRIPTION
### Motivation

- The SSR-enabled `/search` route previously accepted an unbounded `q` parameter and rebuilt the entire Fuse search index per request, allowing long attacker-controlled queries to tie up SSR worker CPU. 
- The change aims to restore safe server-side behavior by rejecting oversized queries early and avoiding per-request index rebuilds.

### Description

- Add a global `SEARCH_QUERY_MAX_LENGTH` (100 chars) and reject queries longer than this at validation and loader boundaries to avoid expensive work on oversized input. 
- Cache the per-version search engine instead of calling `createSheetsSearchEngine` on every request to prevent repeated index construction. 
- Wire the new limit into the route validator and the loader so oversized queries throw a `RangeError` before trimming or searching. 
- Add a regression test that asserts oversized queries are rejected both at route validation and when invoking the loader directly.

### Testing

- `pnpm --filter @gekichumai/dxrating-web exec vitest run src/routes/__tests__/-search.test.ts` — tests passed (3 tests). 
- `pnpm lint` — completed with 0 errors and repo pre-existing warnings remained. 
- `pnpm exec oxfmt --check apps/web/src/routes/search.tsx apps/web/src/components/sheet/searchQuerySeed.ts apps/web/src/routes/__tests__/-search.test.ts` — formatting check passed for modified files. 
- `pnpm build` — full build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7cd2a210dc833086cdf9c5a41016eb)