### PR TITLE
feat(auth): enforce account deletion cascades

### DIFF
--- a/apps/backend/drizzle/0011_ancient_maelstrom.sql
+++ b/apps/backend/drizzle/0011_ancient_maelstrom.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "comments" DROP CONSTRAINT "comments_parent_id_comments_id_fk";
+--> statement-breakpoint
+ALTER TABLE "song_aliases" DROP CONSTRAINT "song_aliases_created_by_user_id_fk";
+--> statement-breakpoint
+ALTER TABLE "tag_songs" DROP CONSTRAINT "tag_songs_tag_id_tags_id_fk";
+--> statement-breakpoint
+ALTER TABLE "comments" ADD CONSTRAINT "comments_parent_id_comments_id_fk" FOREIGN KEY ("parent_id") REFERENCES "public"."comments"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "song_aliases" ADD CONSTRAINT "song_aliases_created_by_user_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "tag_songs" ADD CONSTRAINT "tag_songs_tag_id_tags_id_fk" FOREIGN KEY ("tag_id") REFERENCES "public"."tags"("id") ON DELETE cascade ON UPDATE no action;

--- a/apps/backend/drizzle/meta/0011_snapshot.json
+++ b/apps/backend/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,3370 @@
+{
+  "id": "f96e82f4-4945-4205-a807-8b1d0f0dd997",
+  "prevId": "9fc39a2d-f17c-4d4b-b259-523420bf86cd",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "arcade.chains": {
+      "name": "chains",
+      "schema": "arcade",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_codes": {
+          "name": "country_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chains_country_codes_nonempty_check": {
+          "name": "chains_country_codes_nonempty_check",
+          "value": "cardinality(\"arcade\".\"chains\".\"country_codes\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "arcade.crawl_runs": {
+      "name": "crawl_runs",
+      "schema": "arcade",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_complete": {
+          "name": "is_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "record_count": {
+          "name": "record_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "crawl_runs_source_started_idx": {
+          "name": "crawl_runs_source_started_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "arcade_crawl_runs_status_check": {
+          "name": "arcade_crawl_runs_status_check",
+          "value": "\"arcade\".\"crawl_runs\".\"status\" in ('running', 'succeeded', 'failed')"
+        },
+        "arcade_crawl_runs_record_count_check": {
+          "name": "arcade_crawl_runs_record_count_check",
+          "value": "\"arcade\".\"crawl_runs\".\"record_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "arcade.game_source_mappings": {
+      "name": "game_source_mappings",
+      "schema": "arcade",
+      "columns": {
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_game_id": {
+          "name": "source_game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_name": {
+          "name": "external_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "game_source_mappings_game_id_idx": {
+          "name": "game_source_mappings_game_id_idx",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_source_mappings_game_id_games_id_fk": {
+          "name": "game_source_mappings_game_id_games_id_fk",
+          "tableFrom": "game_source_mappings",
+          "tableTo": "games",
+          "schemaTo": "arcade",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "game_source_mappings_source_source_game_id_pk": {
+          "name": "game_source_mappings_source_source_game_id_pk",
+          "columns": [
+            "source",
+            "source_game_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "arcade.games": {
+      "name": "games",
+      "schema": "arcade",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "arcade_games_active_name_idx": {
+          "name": "arcade_games_active_name_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "arcade.geocoding_coordinate_decisions": {
+      "name": "geocoding_coordinate_decisions",
+      "schema": "arcade",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "observation_id": {
+          "name": "observation_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wgs84_longitude": {
+          "name": "wgs84_longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wgs84_latitude": {
+          "name": "wgs84_latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "geocoding_coordinate_decisions_venue_idx": {
+          "name": "geocoding_coordinate_decisions_venue_idx",
+          "columns": [
+            {
+              "expression": "venue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "geocoding_coordinate_decisions_observation_id_geocoding_observations_id_fk": {
+          "name": "geocoding_coordinate_decisions_observation_id_geocoding_observations_id_fk",
+          "tableFrom": "geocoding_coordinate_decisions",
+          "tableTo": "geocoding_observations",
+          "schemaTo": "arcade",
+          "columnsFrom": [
+            "observation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "geocoding_coordinate_decisions_venue_id_venues_id_fk": {
+          "name": "geocoding_coordinate_decisions_venue_id_venues_id_fk",
+          "tableFrom": "geocoding_coordinate_decisions",
+          "tableTo": "venues",
+          "schemaTo": "arcade",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "geocoding_coordinate_decisions_observation_id_key": {
+          "name": "geocoding_coordinate_decisions_observation_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "observation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "geocoding_coordinate_decisions_decision_check": {
+          "name": "geocoding_coordinate_decisions_decision_check",
+          "value": "\"arcade\".\"geocoding_coordinate_decisions\".\"decision\" in ('applied', 'skipped_non_null')"
+        },
+        "geocoding_coordinate_decisions_latitude_range_check": {
+          "name": "geocoding_coordinate_decisions_latitude_range_check",
+          "value": "\"arcade\".\"geocoding_coordinate_decisions\".\"wgs84_latitude\" between -90 and 90"
+        },
+        "geocoding_coordinate_decisions_longitude_range_check": {
+          "name": "geocoding_coordinate_decisions_longitude_range_check",
+          "value": "\"arcade\".\"geocoding_coordinate_decisions\".\"wgs84_longitude\" between -180 and 180"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "arcade.geocoding_coordinate_invalidations": {
+      "name": "geocoding_coordinate_invalidations",
+      "schema": "arcade",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "decision_id": {
+          "name": "decision_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invalidated_at": {
+          "name": "invalidated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prior_wgs84_longitude": {
+          "name": "prior_wgs84_longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prior_wgs84_latitude": {
+          "name": "prior_wgs84_latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "geocoding_coordinate_invalidations_venue_idx": {
+          "name": "geocoding_coordinate_invalidations_venue_idx",
+          "columns": [
+            {
+              "expression": "venue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "invalidated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "geocoding_coordinate_invalidations_decision_id_geocoding_coordinate_decisions_id_fk": {
+          "name": "geocoding_coordinate_invalidations_decision_id_geocoding_coordinate_decisions_id_fk",
+          "tableFrom": "geocoding_coordinate_invalidations",
+          "tableTo": "geocoding_coordinate_decisions",
+          "schemaTo": "arcade",
+          "columnsFrom": [
+            "decision_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "geocoding_coordinate_invalidations_venue_id_venues_id_fk": {
+          "name": "geocoding_coordinate_invalidations_venue_id_venues_id_fk",
+          "tableFrom": "geocoding_coordinate_invalidations",
+          "tableTo": "venues",
+          "schemaTo": "arcade",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "geocoding_coordinate_invalidations_decision_id_key": {
+          "name": "geocoding_coordinate_invalidations_decision_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "decision_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "geocoding_coordinate_invalidations_reason_check": {
+          "name": "geocoding_coordinate_invalidations_reason_check",
+          "value": "\"arcade\".\"geocoding_coordinate_invalidations\".\"reason\" in ('trusted_source_attached', 'trusted_source_changed')"
+        },
+        "geocoding_coordinate_invalidations_latitude_range_check": {
+          "name": "geocoding_coordinate_invalidations_latitude_range_check",
+          "value": "\"arcade\".\"geocoding_coordinate_invalidations\".\"prior_wgs84_latitude\" between -90 and 90"
+        },
+        "geocoding_coordinate_invalidations_longitude_range_check": {
+          "name": "geocoding_coordinate_invalidations_longitude_range_check",
+          "value": "\"arcade\".\"geocoding_coordinate_invalidations\".\"prior_wgs84_longitude\" between -180 and 180"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "arcade.geocoding_observations": {
+      "name": "geocoding_observations",
+      "schema": "arcade",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_address": {
+          "name": "request_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_city": {
+          "name": "request_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_hash": {
+          "name": "request_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "infocode": {
+          "name": "infocode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gcj02_longitude": {
+          "name": "gcj02_longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gcj02_latitude": {
+          "name": "gcj02_latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_crs": {
+          "name": "reported_crs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wgs84_longitude": {
+          "name": "wgs84_longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wgs84_latitude": {
+          "name": "wgs84_latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_crs": {
+          "name": "normalized_crs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quality": {
+          "name": "quality",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terminal": {
+          "name": "terminal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "geocoding_observations_venue_observed_idx": {
+          "name": "geocoding_observations_venue_observed_idx",
+          "columns": [
+            {
+              "expression": "venue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "geocoding_observations_resume_idx": {
+          "name": "geocoding_observations_resume_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "venue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "request_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "terminal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "geocoding_observations_venue_id_venues_id_fk": {
+          "name": "geocoding_observations_venue_id_venues_id_fk",
+          "tableFrom": "geocoding_observations",
+          "tableTo": "venues",
+          "schemaTo": "arcade",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "geocoding_observations_operation_check": {
+          "name": "geocoding_observations_operation_check",
+          "value": "\"arcade\".\"geocoding_observations\".\"operation\" in ('geocode', 'poi_search')"
+        },
+        "geocoding_observations_request_hash_check": {
+          "name": "geocoding_observations_request_hash_check",
+          "value": "length(\"arcade\".\"geocoding_observations\".\"request_hash\") = 64"
+        },
+        "geocoding_observations_attempt_check": {
+          "name": "geocoding_observations_attempt_check",
+          "value": "\"arcade\".\"geocoding_observations\".\"attempt\" > 0"
+        },
+        "geocoding_observations_status_check": {
+          "name": "geocoding_observations_status_check",
+          "value": "\"arcade\".\"geocoding_observations\".\"status\" in ('accepted', 'rejected', 'error')"
+        },
+        "geocoding_observations_reported_crs_check": {
+          "name": "geocoding_observations_reported_crs_check",
+          "value": "\"arcade\".\"geocoding_observations\".\"reported_crs\" = 'GCJ-02'"
+        },
+        "geocoding_observations_normalized_crs_check": {
+          "name": "geocoding_observations_normalized_crs_check",
+          "value": "\"arcade\".\"geocoding_observations\".\"normalized_crs\" = 'WGS84'"
+        },
+        "geocoding_observations_quality_check": {
+          "name": "geocoding_observations_quality_check",
+          "value": "\"arcade\".\"geocoding_observations\".\"quality\" is null or \"arcade\".\"geocoding_observations\".\"quality\" between 0 and 1"
+        },
+        "geocoding_observations_gcj02_paired_check": {
+          "name": "geocoding_observations_gcj02_paired_check",
+          "value": "(\"arcade\".\"geocoding_observations\".\"gcj02_latitude\" is null) = (\"arcade\".\"geocoding_observations\".\"gcj02_longitude\" is null)"
+        },
+        "geocoding_observations_wgs84_paired_check": {
+          "name": "geocoding_observations_wgs84_paired_check",
+          "value": "(\"arcade\".\"geocoding_observations\".\"wgs84_latitude\" is null) = (\"arcade\".\"geocoding_observations\".\"wgs84_longitude\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "arcade.installation_identities": {
+      "name": "installation_identities",
+      "schema": "arcade",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cabinet_model": {
+          "name": "cabinet_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "installation_identities_venue_idx": {
+          "name": "installation_identities_venue_idx",
+          "columns": [
+            {
+              "expression": "venue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "installation_identities_game_idx": {
+          "name": "installation_identities_game_idx",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "installation_identities_venue_id_venues_id_fk": {
+          "name": "installation_identities_venue_id_venues_id_fk",
+          "tableFrom": "installation_identities",
+          "tableTo": "venues",
+          "schemaTo": "arcade",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "installation_identities_game_id_games_id_fk": {
+          "name": "installation_identities_game_id_games_id_fk",
+          "tableFrom": "installation_identities",
+          "tableTo": "games",
+          "schemaTo": "arcade",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "installation_identities_public_id_unique": {
+          "name": "installation_identities_public_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_id"
+          ]
+        },
+        "installation_identities_logical_identity_unique": {
+          "name": "installation_identities_logical_identity_unique",
+          "nullsNotDistinct": true,
+          "columns": [
+            "venue_id",
+            "game_id",
+            "region",
+            "network",
+            "version",
+            "cabinet_model"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "installation_identities_public_id_check": {
+          "name": "installation_identities_public_id_check",
+          "value": "\"arcade\".\"installation_identities\".\"public_id\" ~ '^dins_[23456789abcdefghjkmnpqrstvwxyz]{10}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "arcade.installation_observations": {
+      "name": "installation_observations",
+      "schema": "arcade",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "crawl_run_id": {
+          "name": "crawl_run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_venue_id": {
+          "name": "source_venue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machine_count": {
+          "name": "machine_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cabinet_model": {
+          "name": "cabinet_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "installation_observations_game_idx": {
+          "name": "installation_observations_game_idx",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "installation_observations_source_venue_idx": {
+          "name": "installation_observations_source_venue_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_venue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "installation_observations_observed_idx": {
+          "name": "installation_observations_observed_idx",
+          "columns": [
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "installation_observations_crawl_run_id_crawl_runs_id_fk": {
+          "name": "installation_observations_crawl_run_id_crawl_runs_id_fk",
+          "tableFrom": "installation_observations",
+          "tableTo": "crawl_runs",
+          "schemaTo": "arcade",
+          "columnsFrom": [
+            "crawl_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "installation_observations_game_id_games_id_fk": {
+          "name": "installation_observations_game_id_games_id_fk",
+          "tableFrom": "installation_observations",
+          "tableTo": "games",
+          "schemaTo": "arcade",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "arcade_installation_observations_identity_unique": {
+          "name": "arcade_installation_observations_identity_unique",
+          "nullsNotDistinct": true,
+          "columns": [
+            "crawl_run_id",
+            "source",
+            "source_venue_id",
+            "game_id",
+            "region",
+            "network",
+            "version",
+            "cabinet_model"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "arcade_installation_observations_count_check": {
+          "name": "arcade_installation_observations_count_check",
+          "value": "\"arcade\".\"installation_observations\".\"machine_count\" is null or \"arcade\".\"installation_observations\".\"machine_count\" >= 0"
+        },
+        "arcade_installation_observations_confidence_check": {
+          "name": "arcade_installation_observations_confidence_check",
+          "value": "\"arcade\".\"installation_observations\".\"confidence\" is null or \"arcade\".\"installation_observations\".\"confidence\" between 0 and 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "arcade.installations": {
+      "name": "installations",
+      "schema": "arcade",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_identity_id": {
+          "name": "installation_identity_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cabinet_model": {
+          "name": "cabinet_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machine_count": {
+          "name": "machine_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_crawl_run_id": {
+          "name": "last_crawl_run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "absent_since": {
+          "name": "absent_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "installations_game_idx": {
+          "name": "installations_game_idx",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "installations_identity_idx": {
+          "name": "installations_identity_idx",
+          "columns": [
+            {
+              "expression": "installation_identity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "installations_venue_active_idx": {
+          "name": "installations_venue_active_idx",
+          "columns": [
+            {
+              "expression": "venue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "absent_since",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "installations_game_active_idx": {
+          "name": "installations_game_active_idx",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "absent_since",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "installations_installation_identity_id_installation_identities_id_fk": {
+          "name": "installations_installation_identity_id_installation_identities_id_fk",
+          "tableFrom": "installations",
+          "tableTo": "installation_identities",
+          "schemaTo": "arcade",
+          "columnsFrom": [
+            "installation_identity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "installations_venue_id_venues_id_fk": {
+          "name": "installations_venue_id_venues_id_fk",
+          "tableFrom": "installations",
+          "tableTo": "venues",
+          "schemaTo": "arcade",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "installations_game_id_games_id_fk": {
+          "name": "installations_game_id_games_id_fk",
+          "tableFrom": "installations",
+          "tableTo": "games",
+          "schemaTo": "arcade",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "installations_last_crawl_run_id_crawl_runs_id_fk": {
+          "name": "installations_last_crawl_run_id_crawl_runs_id_fk",
+          "tableFrom": "installations",
+          "tableTo": "crawl_runs",
+          "schemaTo": "arcade",
+          "columnsFrom": [
+            "last_crawl_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "arcade_installations_identity_unique": {
+          "name": "arcade_installations_identity_unique",
+          "nullsNotDistinct": true,
+          "columns": [
+            "venue_id",
+            "game_id",
+            "source",
+            "region",
+            "network",
+            "version",
+            "cabinet_model"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "arcade_installations_count_check": {
+          "name": "arcade_installations_count_check",
+          "value": "\"arcade\".\"installations\".\"machine_count\" is null or \"arcade\".\"installations\".\"machine_count\" >= 0"
+        },
+        "arcade_installations_confidence_check": {
+          "name": "arcade_installations_confidence_check",
+          "value": "\"arcade\".\"installations\".\"confidence\" is null or \"arcade\".\"installations\".\"confidence\" between 0 and 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "arcade.venue_chain_decisions": {
+      "name": "venue_chain_decisions",
+      "schema": "arcade",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classifier_version": {
+          "name": "classifier_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_chain_id": {
+          "name": "previous_chain_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "venue_chain_decisions_venue_idx": {
+          "name": "venue_chain_decisions_venue_idx",
+          "columns": [
+            {
+              "expression": "venue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decided_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "venue_chain_decisions_venue_id_venues_id_fk": {
+          "name": "venue_chain_decisions_venue_id_venues_id_fk",
+          "tableFrom": "venue_chain_decisions",
+          "tableTo": "venues",
+          "schemaTo": "arcade",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "venue_chain_decisions_chain_id_chains_id_fk": {
+          "name": "venue_chain_decisions_chain_id_chains_id_fk",
+          "tableFrom": "venue_chain_decisions",
+          "tableTo": "chains",
+          "schemaTo": "arcade",
+          "columnsFrom": [
+            "chain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "venue_chain_decisions_previous_chain_id_chains_id_fk": {
+          "name": "venue_chain_decisions_previous_chain_id_chains_id_fk",
+          "tableFrom": "venue_chain_decisions",
+          "tableTo": "chains",
+          "schemaTo": "arcade",
+          "columnsFrom": [
+            "previous_chain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "venue_chain_decisions_input_hash_check": {
+          "name": "venue_chain_decisions_input_hash_check",
+          "value": "length(\"arcade\".\"venue_chain_decisions\".\"input_hash\") = 64"
+        },
+        "venue_chain_decisions_decision_check": {
+          "name": "venue_chain_decisions_decision_check",
+          "value": "\"arcade\".\"venue_chain_decisions\".\"decision\" in ('matched', 'unmatched', 'ambiguous')"
+        },
+        "venue_chain_decisions_chain_coherence_check": {
+          "name": "venue_chain_decisions_chain_coherence_check",
+          "value": "(\"arcade\".\"venue_chain_decisions\".\"decision\" = 'matched') = (\"arcade\".\"venue_chain_decisions\".\"chain_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "arcade.venue_matches": {
+      "name": "venue_matches",
+      "schema": "arcade",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_venue_id": {
+          "name": "source_venue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crawl_run_id": {
+          "name": "crawl_run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "venue_matches_source_idx": {
+          "name": "venue_matches_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_venue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "venue_matches_venue_id_idx": {
+          "name": "venue_matches_venue_id_idx",
+          "columns": [
+            {
+              "expression": "venue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "venue_matches_venue_id_venues_id_fk": {
+          "name": "venue_matches_venue_id_venues_id_fk",
+          "tableFrom": "venue_matches",
+          "tableTo": "venues",
+          "schemaTo": "arcade",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "venue_matches_crawl_run_id_crawl_runs_id_fk": {
+          "name": "venue_matches_crawl_run_id_crawl_runs_id_fk",
+          "tableFrom": "venue_matches",
+          "tableTo": "crawl_runs",
+          "schemaTo": "arcade",
+          "columnsFrom": [
+            "crawl_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "arcade_venue_matches_decision_check": {
+          "name": "arcade_venue_matches_decision_check",
+          "value": "\"arcade\".\"venue_matches\".\"decision\" in ('exact_source_id', 'curated', 'auto', 'ambiguous', 'unmatched')"
+        },
+        "arcade_venue_matches_score_check": {
+          "name": "arcade_venue_matches_score_check",
+          "value": "\"arcade\".\"venue_matches\".\"score\" is null or \"arcade\".\"venue_matches\".\"score\" between 0 and 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "arcade.venue_sources": {
+      "name": "venue_sources",
+      "schema": "arcade",
+      "columns": {
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_venue_id": {
+          "name": "source_venue_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_address": {
+          "name": "normalized_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_run_id": {
+          "name": "first_seen_run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_run_id": {
+          "name": "last_seen_run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "raw": {
+          "name": "raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "venue_sources_venue_id_idx": {
+          "name": "venue_sources_venue_id_idx",
+          "columns": [
+            {
+              "expression": "venue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "venue_sources_normalized_name_idx": {
+          "name": "venue_sources_normalized_name_idx",
+          "columns": [
+            {
+              "expression": "normalized_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "venue_sources_active_seen_idx": {
+          "name": "venue_sources_active_seen_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_seen_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "venue_sources_venue_id_venues_id_fk": {
+          "name": "venue_sources_venue_id_venues_id_fk",
+          "tableFrom": "venue_sources",
+          "tableTo": "venues",
+          "schemaTo": "arcade",
+          "columnsFrom": [
+            "venue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "venue_sources_first_seen_run_id_crawl_runs_id_fk": {
+          "name": "venue_sources_first_seen_run_id_crawl_runs_id_fk",
+          "tableFrom": "venue_sources",
+          "tableTo": "crawl_runs",
+          "schemaTo": "arcade",
+          "columnsFrom": [
+            "first_seen_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "venue_sources_last_seen_run_id_crawl_runs_id_fk": {
+          "name": "venue_sources_last_seen_run_id_crawl_runs_id_fk",
+          "tableFrom": "venue_sources",
+          "tableTo": "crawl_runs",
+          "schemaTo": "arcade",
+          "columnsFrom": [
+            "last_seen_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "venue_sources_source_source_venue_id_pk": {
+          "name": "venue_sources_source_source_venue_id_pk",
+          "columns": [
+            "source",
+            "source_venue_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "venue_sources_coordinates_paired_check": {
+          "name": "venue_sources_coordinates_paired_check",
+          "value": "(\"arcade\".\"venue_sources\".\"latitude\" is null) = (\"arcade\".\"venue_sources\".\"longitude\" is null)"
+        },
+        "venue_sources_latitude_range_check": {
+          "name": "venue_sources_latitude_range_check",
+          "value": "\"arcade\".\"venue_sources\".\"latitude\" is null or \"arcade\".\"venue_sources\".\"latitude\" between -90 and 90"
+        },
+        "venue_sources_longitude_range_check": {
+          "name": "venue_sources_longitude_range_check",
+          "value": "\"arcade\".\"venue_sources\".\"longitude\" is null or \"arcade\".\"venue_sources\".\"longitude\" between -180 and 180"
+        },
+        "venue_sources_coordinates_nonzero_check": {
+          "name": "venue_sources_coordinates_nonzero_check",
+          "value": "\"arcade\".\"venue_sources\".\"latitude\" is null or \"arcade\".\"venue_sources\".\"latitude\" <> 0 or \"arcade\".\"venue_sources\".\"longitude\" <> 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "arcade.venues": {
+      "name": "venues",
+      "schema": "arcade",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalized_address": {
+          "name": "normalized_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "venues_normalized_name_idx": {
+          "name": "venues_normalized_name_idx",
+          "columns": [
+            {
+              "expression": "normalized_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "venues_chain_id_idx": {
+          "name": "venues_chain_id_idx",
+          "columns": [
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "venues_location_idx": {
+          "name": "venues_location_idx",
+          "columns": [
+            {
+              "expression": "country_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "region",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "city",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "venues_coordinates_idx": {
+          "name": "venues_coordinates_idx",
+          "columns": [
+            {
+              "expression": "latitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "longitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "venues_name_address_idx": {
+          "name": "venues_name_address_idx",
+          "columns": [
+            {
+              "expression": "normalized_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "venues_chain_id_chains_id_fk": {
+          "name": "venues_chain_id_chains_id_fk",
+          "tableFrom": "venues",
+          "tableTo": "chains",
+          "schemaTo": "arcade",
+          "columnsFrom": [
+            "chain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "venues_public_id_unique": {
+          "name": "venues_public_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "venues_public_id_check": {
+          "name": "venues_public_id_check",
+          "value": "\"arcade\".\"venues\".\"public_id\" ~ '^dven_[23456789abcdefghjkmnpqrstvwxyz]{10}$'"
+        },
+        "venues_coordinates_paired_check": {
+          "name": "venues_coordinates_paired_check",
+          "value": "(\"arcade\".\"venues\".\"latitude\" is null) = (\"arcade\".\"venues\".\"longitude\" is null)"
+        },
+        "venues_latitude_range_check": {
+          "name": "venues_latitude_range_check",
+          "value": "\"arcade\".\"venues\".\"latitude\" is null or \"arcade\".\"venues\".\"latitude\" between -90 and 90"
+        },
+        "venues_longitude_range_check": {
+          "name": "venues_longitude_range_check",
+          "value": "\"arcade\".\"venues\".\"longitude\" is null or \"arcade\".\"venues\".\"longitude\" between -180 and 180"
+        },
+        "venues_coordinates_nonzero_check": {
+          "name": "venues_coordinates_nonzero_check",
+          "value": "\"arcade\".\"venues\".\"latitude\" is null or \"arcade\".\"venues\".\"latitude\" <> 0 or \"arcade\".\"venues\".\"longitude\" <> 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_id": {
+          "name": "song_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sheet_type": {
+          "name": "sheet_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sheet_difficulty": {
+          "name": "sheet_difficulty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comments_created_by_user_id_fk": {
+          "name": "comments_created_by_user_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comments_parent_id_comments_id_fk": {
+          "name": "comments_parent_id_comments_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lxns_oauth_states": {
+      "name": "lxns_oauth_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lxns_oauth_states_user_id_user_id_fk": {
+          "name": "lxns_oauth_states_user_id_user_id_fk",
+          "tableFrom": "lxns_oauth_states",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "lxns_oauth_states_state_unique": {
+          "name": "lxns_oauth_states_state_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "state"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lxns_oauth_tokens": {
+      "name": "lxns_oauth_tokens",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lxns_oauth_tokens_user_id_user_id_fk": {
+          "name": "lxns_oauth_tokens_user_id_user_id_fk",
+          "tableFrom": "lxns_oauth_tokens",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_id_user_id_fk": {
+          "name": "profiles_id_user_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "user",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.song_aliases": {
+      "name": "song_aliases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "song_id": {
+          "name": "song_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "song_aliases_created_by_user_id_fk": {
+          "name": "song_aliases_created_by_user_id_fk",
+          "tableFrom": "song_aliases",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tag_groups": {
+      "name": "tag_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "localized_name": {
+          "name": "localized_name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tag_songs": {
+      "name": "tag_songs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_id": {
+          "name": "song_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sheet_type": {
+          "name": "sheet_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sheet_difficulty": {
+          "name": "sheet_difficulty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tag_songs_tag_id_tags_id_fk": {
+          "name": "tag_songs_tag_id_tags_id_fk",
+          "tableFrom": "tag_songs",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tag_songs_created_by_user_id_fk": {
+          "name": "tag_songs_created_by_user_id_fk",
+          "tableFrom": "tag_songs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "localized_name": {
+          "name": "localized_name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "localized_description": {
+          "name": "localized_description",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tags_created_by_user_id_fk": {
+          "name": "tags_created_by_user_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tags_group_id_tag_groups_id_fk": {
+          "name": "tags_group_id_tag_groups_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "tag_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_credentialID_idx": {
+          "name": "passkey_credentialID_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "arcade": "arcade"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1785610151236,
       "tag": "0010_enforce_arcade_public_identities",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1788016139847,
+      "tag": "0011_ancient_maelstrom",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -43,7 +43,7 @@ export const tagSongs = pgTable('tag_songs', {
   id: bigserial('id', { mode: 'number' }).primaryKey(),
   created_at: timestamp('created_at').defaultNow().notNull(),
   tag_id: bigint('tag_id', { mode: 'number' })
-    .references(() => tags.id)
+    .references(() => tags.id, { onDelete: 'cascade' })
     .notNull(),
   song_id: text('song_id').notNull(),
   sheet_type: text('sheet_type').notNull(),
@@ -70,7 +70,9 @@ export const comments = pgTable('comments', {
   song_id: text('song_id').notNull(),
   sheet_type: text('sheet_type').notNull(),
   sheet_difficulty: text('sheet_difficulty').notNull(),
-  parent_id: bigint('parent_id', { mode: 'number' }).references((): AnyPgColumn => comments.id),
+  parent_id: bigint('parent_id', { mode: 'number' }).references((): AnyPgColumn => comments.id, {
+    onDelete: 'set null',
+  }),
   content: text('content').notNull(),
 })
 
@@ -79,7 +81,7 @@ export const songAliases = pgTable('song_aliases', {
   created_at: timestamp('created_at').defaultNow().notNull(),
   song_id: text('song_id').notNull(),
   name: text('name').notNull(),
-  created_by: text('created_by').references(() => user.id, { onDelete: 'set null' }),
+  created_by: text('created_by').references(() => user.id, { onDelete: 'cascade' }),
 })
 
 // --- LXNS OAuth Tables ---

--- a/apps/backend/src/test/account-deletion-schema.test.ts
+++ b/apps/backend/src/test/account-deletion-schema.test.ts
@@ -1,0 +1,81 @@
+import pg from 'pg'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { cleanDatabase, setupTestServer, signUp, teardownTestServer } from './setup.js'
+
+describe('Account deletion database relationships', () => {
+  beforeAll(async () => {
+    await setupTestServer()
+  })
+
+  afterAll(async () => {
+    await teardownTestServer()
+  })
+
+  beforeEach(async () => {
+    await cleanDatabase()
+  })
+
+  it('deletes user content without deleting replies from other users', async () => {
+    await signUp('delete@example.com', 'password123', 'Delete Me')
+    await signUp('survivor@example.com', 'password123', 'Survivor')
+
+    const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL })
+    try {
+      const users = await pool.query<{ id: string; email: string }>(
+        `SELECT id, email FROM "user" WHERE email IN ('delete@example.com', 'survivor@example.com')`,
+      )
+      const deletedUserId = users.rows.find((user) => user.email === 'delete@example.com')!.id
+      const survivorId = users.rows.find((user) => user.email === 'survivor@example.com')!.id
+
+      const tagGroup = await pool.query<{ id: number }>(
+        `INSERT INTO tag_groups (localized_name, color) VALUES ('{"en":"Test"}', '#000000') RETURNING id`,
+      )
+      const tag = await pool.query<{ id: number }>(
+        `INSERT INTO tags (created_by, localized_name, localized_description, group_id)
+         VALUES ($1, '{"en":"Delete"}', '{"en":"Delete"}', $2) RETURNING id`,
+        [deletedUserId, tagGroup.rows[0]!.id],
+      )
+      await pool.query(
+        `INSERT INTO tag_songs (tag_id, song_id, sheet_type, sheet_difficulty, created_by)
+         VALUES ($1, 'song', 'dx', 'master', $2)`,
+        [tag.rows[0]!.id, survivorId],
+      )
+      await pool.query(`INSERT INTO song_aliases (song_id, name, created_by) VALUES ('song', 'Deleted alias', $1)`, [
+        deletedUserId,
+      ])
+
+      const parent = await pool.query<{ id: number }>(
+        `INSERT INTO comments (created_by, song_id, sheet_type, sheet_difficulty, content)
+         VALUES ($1, 'song', 'dx', 'master', 'Deleted comment') RETURNING id`,
+        [deletedUserId],
+      )
+      const reply = await pool.query<{ id: number }>(
+        `INSERT INTO comments (created_by, song_id, sheet_type, sheet_difficulty, parent_id, content)
+         VALUES ($1, 'song', 'dx', 'master', $2, 'Surviving reply') RETURNING id`,
+        [survivorId, parent.rows[0]!.id],
+      )
+
+      await pool.query(`DELETE FROM "user" WHERE id = $1`, [deletedUserId])
+
+      const [deletedUser, deletedTag, deletedTagSong, deletedAlias, deletedComment, survivingReply] = await Promise.all(
+        [
+          pool.query(`SELECT id FROM "user" WHERE id = $1`, [deletedUserId]),
+          pool.query(`SELECT id FROM tags WHERE id = $1`, [tag.rows[0]!.id]),
+          pool.query(`SELECT id FROM tag_songs WHERE tag_id = $1`, [tag.rows[0]!.id]),
+          pool.query(`SELECT id FROM song_aliases WHERE created_by = $1`, [deletedUserId]),
+          pool.query(`SELECT id FROM comments WHERE id = $1`, [parent.rows[0]!.id]),
+          pool.query<{ parent_id: number | null }>(`SELECT parent_id FROM comments WHERE id = $1`, [reply.rows[0]!.id]),
+        ],
+      )
+
+      expect(deletedUser.rowCount).toBe(0)
+      expect(deletedTag.rowCount).toBe(0)
+      expect(deletedTagSong.rowCount).toBe(0)
+      expect(deletedAlias.rowCount).toBe(0)
+      expect(deletedComment.rowCount).toBe(0)
+      expect(survivingReply.rows).toEqual([{ parent_id: null }])
+    } finally {
+      await pool.end()
+    }
+  })
+})

--- a/apps/backend/src/test/setup.ts
+++ b/apps/backend/src/test/setup.ts
@@ -45,6 +45,7 @@ export async function setupTestServer() {
     '0008_arcade_chain_audit_alignment.sql',
     '0009_arcade_public_identities.sql',
     '0010_enforce_arcade_public_identities.sql',
+    '0011_ancient_maelstrom.sql',
   ]
 
   for (const file of migrationFiles) {


### PR DESCRIPTION
## Summary

- cascade account deletion through comments, tags, tag assignments, and song aliases
- detach replies from a deleted parent comment so other users' replies remain valid
- include the generated Drizzle migration and an integration test for the deletion graph

This is PR 1 of 2 in the backend stack. Continue with #346.

## Validation

- `pnpm --filter @gekichumai/backend exec vitest run src/test/account-deletion-schema.test.ts src/test/account-deletion.test.ts src/test/oauth-revocation.test.ts` (7 tests passed)

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>
