### PR TITLE
feat(auth): add permanent account deletion endpoint

### DIFF
--- a/apps/backend/src/auth.ts
+++ b/apps/backend/src/auth.ts
@@ -10,6 +10,8 @@ import { passkey } from '@better-auth/passkey'
 import { i18n } from '@better-auth/i18n'
 import { config } from './config.js'
 import { createAppleClientSecretGenerator } from './lib/apple-client-secret.js'
+import { revokeOAuthGrants } from './lib/oauth-revocation.js'
+import { eq } from 'drizzle-orm'
 
 const crossSubDomainCookies = config.auth.cookieDomain
   ? { enabled: true as const, domain: config.auth.cookieDomain }
@@ -56,6 +58,46 @@ export const auth = betterAuth({
     password: {
       hash: async (password) => bcrypt.hash(password, 10),
       verify: async ({ hash, password }) => bcrypt.compare(password, hash),
+    },
+  },
+  user: {
+    deleteUser: {
+      enabled: true,
+      beforeDelete: async (user) => {
+        const accounts = await db
+          .select({
+            providerId: authSchema.account.providerId,
+            accessToken: authSchema.account.accessToken,
+            refreshToken: authSchema.account.refreshToken,
+          })
+          .from(authSchema.account)
+          .where(eq(authSchema.account.userId, user.id))
+
+        const revocationIssues = await revokeOAuthGrants(accounts, {
+          ...(appleProvider
+            ? {
+                apple: {
+                  clientId: appleProvider.clientId,
+                  clientSecret: () => appleProvider.clientSecret,
+                },
+              }
+            : {}),
+          ...(config.auth.github.clientId && config.auth.github.clientSecret
+            ? {
+                github: {
+                  clientId: config.auth.github.clientId,
+                  clientSecret: config.auth.github.clientSecret,
+                },
+              }
+            : {}),
+        })
+
+        for (const issue of revocationIssues) {
+          console.warn('OAuth grant revocation issue during account deletion', issue)
+        }
+
+        await db.delete(authSchema.verification).where(eq(authSchema.verification.value, user.id))
+      },
     },
   },
   advanced: {

--- a/apps/backend/src/lib/oauth-revocation.ts
+++ b/apps/backend/src/lib/oauth-revocation.ts
@@ -1,0 +1,140 @@
+type OAuthAccount = {
+  providerId: string
+  accessToken: string | null
+  refreshToken: string | null
+}
+
+type OAuthRevocationConfiguration = {
+  apple?: {
+    clientId: string
+    clientSecret: () => string
+  }
+  github?: {
+    clientId: string
+    clientSecret: string
+  }
+}
+
+export type OAuthRevocationIssue = {
+  providerId: string
+  reason: 'missing-configuration' | 'missing-token' | 'request-failed'
+  error?: string
+}
+
+type RevokeOAuthGrantsOptions = {
+  fetch?: typeof globalThis.fetch
+  timeoutMs?: number
+}
+
+const acceptedStatuses: Record<string, ReadonlySet<number>> = {
+  apple: new Set([200]),
+  google: new Set([200, 400]),
+  github: new Set([204, 404]),
+}
+
+export async function revokeOAuthGrants(
+  accounts: OAuthAccount[],
+  configuration: OAuthRevocationConfiguration,
+  options: RevokeOAuthGrantsOptions = {},
+): Promise<OAuthRevocationIssue[]> {
+  const fetchImplementation = options.fetch ?? globalThis.fetch
+  const timeoutMs = options.timeoutMs ?? 5_000
+
+  const results = await Promise.all(
+    accounts
+      .filter((account) => Object.hasOwn(acceptedStatuses, account.providerId))
+      .map(async (account): Promise<OAuthRevocationIssue | undefined> => {
+        try {
+          const request = createRevocationRequest(account, configuration)
+          if ('issue' in request) return request.issue
+
+          const response = await fetchImplementation(request.url, {
+            ...request.init,
+            signal: AbortSignal.timeout(timeoutMs),
+          })
+          if (!acceptedStatuses[account.providerId]!.has(response.status)) {
+            return {
+              providerId: account.providerId,
+              reason: 'request-failed',
+              error: `Unexpected HTTP status ${response.status}`,
+            }
+          }
+        } catch (error) {
+          return {
+            providerId: account.providerId,
+            reason: 'request-failed',
+            error: error instanceof Error ? error.message : 'Unknown revocation error',
+          }
+        }
+      }),
+  )
+
+  return results.filter((issue): issue is OAuthRevocationIssue => issue !== undefined)
+}
+
+function createRevocationRequest(
+  account: OAuthAccount,
+  configuration: OAuthRevocationConfiguration,
+): { url: string; init: RequestInit } | { issue: OAuthRevocationIssue } {
+  switch (account.providerId) {
+    case 'apple': {
+      const provider = configuration.apple
+      if (!provider) return issue(account.providerId, 'missing-configuration')
+
+      const token = account.refreshToken ?? account.accessToken
+      if (!token) return issue(account.providerId, 'missing-token')
+
+      return {
+        url: 'https://appleid.apple.com/auth/revoke',
+        init: {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams({
+            client_id: provider.clientId,
+            client_secret: provider.clientSecret(),
+            token,
+            token_type_hint: account.refreshToken ? 'refresh_token' : 'access_token',
+          }),
+        },
+      }
+    }
+    case 'google': {
+      const token = account.refreshToken ?? account.accessToken
+      if (!token) return issue(account.providerId, 'missing-token')
+
+      return {
+        url: 'https://oauth2.googleapis.com/revoke',
+        init: {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams({ token }),
+        },
+      }
+    }
+    case 'github': {
+      const provider = configuration.github
+      if (!provider) return issue(account.providerId, 'missing-configuration')
+      if (!account.accessToken) return issue(account.providerId, 'missing-token')
+
+      return {
+        url: `https://api.github.com/applications/${encodeURIComponent(provider.clientId)}/token`,
+        init: {
+          method: 'DELETE',
+          headers: {
+            Accept: 'application/vnd.github+json',
+            Authorization: `Basic ${Buffer.from(`${provider.clientId}:${provider.clientSecret}`).toString('base64')}`,
+            'Content-Type': 'application/json',
+            'X-GitHub-Api-Version': '2022-11-28',
+          },
+          body: JSON.stringify({ access_token: account.accessToken }),
+        },
+      }
+    }
+    default:
+      throw new Error(`Unsupported OAuth provider: ${account.providerId}`)
+  }
+}
+
+function issue(providerId: string, reason: OAuthRevocationIssue['reason']): { issue: OAuthRevocationIssue } {
+  return { issue: { providerId, reason } }
+}

--- a/apps/backend/src/test/account-deletion.test.ts
+++ b/apps/backend/src/test/account-deletion.test.ts
@@ -1,0 +1,182 @@
+import pg from 'pg'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import {
+  authenticatedFetch,
+  cleanDatabase,
+  extractSessionCookie,
+  getBaseUrl,
+  setupTestServer,
+  signIn,
+  signUp,
+  teardownTestServer,
+} from './setup.js'
+
+describe('Account deletion', () => {
+  beforeAll(async () => {
+    await setupTestServer()
+  })
+
+  afterAll(async () => {
+    await teardownTestServer()
+  })
+
+  beforeEach(async () => {
+    await cleanDatabase()
+  })
+
+  it('permanently deletes the account and permits signing up again', async () => {
+    await signUp('delete@example.com', 'password123', 'Delete Me')
+    await signUp('survivor@example.com', 'password123', 'Survivor')
+    const signInResponse = await signIn('delete@example.com', 'password123')
+    const cookie = extractSessionCookie(signInResponse)
+
+    const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL })
+    try {
+      const users = await pool.query<{ id: string; email: string }>(
+        `SELECT id, email FROM "user" WHERE email IN ('delete@example.com', 'survivor@example.com')`,
+      )
+      const deletedUserId = users.rows.find((user) => user.email === 'delete@example.com')!.id
+      const survivorId = users.rows.find((user) => user.email === 'survivor@example.com')!.id
+
+      await seedUserData(pool, deletedUserId, survivorId)
+
+      const response = await authenticatedFetch(`${getBaseUrl()}/api/auth/delete-user`, cookie, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password: 'password123' }),
+      })
+
+      expect(response.status).toBe(200)
+      expect(await response.json()).toMatchObject({ success: true, message: 'User deleted' })
+
+      const deletionCounts = await pool.query<{
+        users: string
+        accounts: string
+        sessions: string
+        passkeys: string
+        profiles: string
+        comments: string
+        tags: string
+        tag_songs: string
+        aliases: string
+        lxns_states: string
+        lxns_tokens: string
+        verifications: string
+      }>(
+        `SELECT
+          (SELECT count(*) FROM "user" WHERE id = $1) AS users,
+          (SELECT count(*) FROM account WHERE user_id = $1) AS accounts,
+          (SELECT count(*) FROM session WHERE user_id = $1) AS sessions,
+          (SELECT count(*) FROM passkey WHERE user_id = $1) AS passkeys,
+          (SELECT count(*) FROM profiles WHERE id = $1) AS profiles,
+          (SELECT count(*) FROM comments WHERE created_by = $1) AS comments,
+          (SELECT count(*) FROM tags WHERE created_by = $1) AS tags,
+          (SELECT count(*) FROM tag_songs WHERE created_by = $1) AS tag_songs,
+          (SELECT count(*) FROM song_aliases WHERE created_by = $1) AS aliases,
+          (SELECT count(*) FROM lxns_oauth_states WHERE user_id = $1) AS lxns_states,
+          (SELECT count(*) FROM lxns_oauth_tokens WHERE user_id = $1) AS lxns_tokens,
+          (SELECT count(*) FROM verification WHERE value = $1) AS verifications`,
+        [deletedUserId],
+      )
+      expect(deletionCounts.rows[0]).toEqual({
+        users: '0',
+        accounts: '0',
+        sessions: '0',
+        passkeys: '0',
+        profiles: '0',
+        comments: '0',
+        tags: '0',
+        tag_songs: '0',
+        aliases: '0',
+        lxns_states: '0',
+        lxns_tokens: '0',
+        verifications: '0',
+      })
+
+      const reply = await pool.query<{ parent_id: number | null }>(
+        `SELECT parent_id FROM comments WHERE content = 'Surviving reply'`,
+      )
+      expect(reply.rows).toEqual([{ parent_id: null }])
+
+      const oldSession = await authenticatedFetch(`${getBaseUrl()}/api/auth/get-session`, cookie)
+      expect(await oldSession.json()).toBeNull()
+
+      const replacement = await signUp('delete@example.com', 'password123', 'Replacement')
+      expect(replacement.status).toBe(200)
+    } finally {
+      await pool.end()
+    }
+  })
+
+  it('rejects deletion when the password is incorrect', async () => {
+    await signUp('delete@example.com', 'password123', 'Delete Me')
+    const signInResponse = await signIn('delete@example.com', 'password123')
+    const cookie = extractSessionCookie(signInResponse)
+
+    const response = await authenticatedFetch(`${getBaseUrl()}/api/auth/delete-user`, cookie, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password: 'incorrect-password' }),
+    })
+
+    expect(response.status).toBe(400)
+
+    const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL })
+    try {
+      const user = await pool.query(`SELECT id FROM "user" WHERE email = 'delete@example.com'`)
+      expect(user.rowCount).toBe(1)
+    } finally {
+      await pool.end()
+    }
+  })
+})
+
+async function seedUserData(pool: pg.Pool, deletedUserId: string, survivorId: string) {
+  await pool.query(`INSERT INTO profiles (id, display_name) VALUES ($1, 'Delete Me')`, [deletedUserId])
+  await pool.query(
+    `INSERT INTO passkey
+      (id, name, public_key, user_id, credential_id, counter, device_type, backed_up, transports, aaguid)
+     VALUES ('passkey-delete', 'Delete', 'public-key', $1, 'credential-delete', 0, 'singleDevice', false, '', '')`,
+    [deletedUserId],
+  )
+  await pool.query(`INSERT INTO lxns_oauth_states (state, user_id) VALUES ('delete-state', $1)`, [deletedUserId])
+  await pool.query(
+    `INSERT INTO lxns_oauth_tokens
+      (user_id, access_token, refresh_token, expires_at, scope)
+     VALUES ($1, 'lxns-access', 'lxns-refresh', now() + interval '1 hour', 'read')`,
+    [deletedUserId],
+  )
+  await pool.query(
+    `INSERT INTO verification (id, identifier, value, expires_at)
+     VALUES ('verification-delete', 'reset-password:token', $1, now() + interval '1 hour')`,
+    [deletedUserId],
+  )
+
+  const tagGroup = await pool.query<{ id: number }>(
+    `INSERT INTO tag_groups (localized_name, color) VALUES ('{"en":"Test"}', '#000000') RETURNING id`,
+  )
+  const tag = await pool.query<{ id: number }>(
+    `INSERT INTO tags (created_by, localized_name, localized_description, group_id)
+     VALUES ($1, '{"en":"Delete"}', '{"en":"Delete"}', $2) RETURNING id`,
+    [deletedUserId, tagGroup.rows[0]!.id],
+  )
+  await pool.query(
+    `INSERT INTO tag_songs (tag_id, song_id, sheet_type, sheet_difficulty, created_by)
+     VALUES ($1, 'song', 'dx', 'master', $2)`,
+    [tag.rows[0]!.id, deletedUserId],
+  )
+  await pool.query(`INSERT INTO song_aliases (song_id, name, created_by) VALUES ('song', 'Deleted alias', $1)`, [
+    deletedUserId,
+  ])
+
+  const parent = await pool.query<{ id: number }>(
+    `INSERT INTO comments (created_by, song_id, sheet_type, sheet_difficulty, content)
+     VALUES ($1, 'song', 'dx', 'master', 'Deleted comment') RETURNING id`,
+    [deletedUserId],
+  )
+  await pool.query(
+    `INSERT INTO comments (created_by, song_id, sheet_type, sheet_difficulty, parent_id, content)
+     VALUES ($1, 'song', 'dx', 'master', $2, 'Surviving reply')`,
+    [survivorId, parent.rows[0]!.id],
+  )
+}

--- a/apps/backend/src/test/oauth-revocation.test.ts
+++ b/apps/backend/src/test/oauth-revocation.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest'
+import { revokeOAuthGrants } from '../lib/oauth-revocation.js'
+
+describe('OAuth grant revocation', () => {
+  it('revokes Apple using the refresh token', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => new Response(null, { status: 200 }))
+
+    const issues = await revokeOAuthGrants(
+      [{ providerId: 'apple', accessToken: 'access', refreshToken: 'refresh' }],
+      {
+        apple: {
+          clientId: 'apple-client',
+          clientSecret: () => 'apple-secret',
+        },
+      },
+      { fetch },
+    )
+
+    expect(issues).toEqual([])
+    expect(fetch).toHaveBeenCalledOnce()
+    const [url, init] = fetch.mock.calls[0]!
+    expect(url).toBe('https://appleid.apple.com/auth/revoke')
+    expect(init?.method).toBe('POST')
+    expect(init?.body?.toString()).toBe(
+      'client_id=apple-client&client_secret=apple-secret&token=refresh&token_type_hint=refresh_token',
+    )
+  })
+
+  it('treats an already-invalid Google token as revoked', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => new Response(null, { status: 400 }))
+
+    const issues = await revokeOAuthGrants(
+      [{ providerId: 'google', accessToken: 'access', refreshToken: null }],
+      {},
+      { fetch },
+    )
+
+    expect(issues).toEqual([])
+    expect(fetch.mock.calls[0]![0]).toBe('https://oauth2.googleapis.com/revoke')
+  })
+
+  it('revokes a GitHub application token with application credentials', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => new Response(null, { status: 204 }))
+
+    const issues = await revokeOAuthGrants(
+      [{ providerId: 'github', accessToken: 'access', refreshToken: null }],
+      { github: { clientId: 'github-client', clientSecret: 'github-secret' } },
+      { fetch },
+    )
+
+    expect(issues).toEqual([])
+    const [url, init] = fetch.mock.calls[0]!
+    expect(url).toBe('https://api.github.com/applications/github-client/token')
+    expect(init?.method).toBe('DELETE')
+    expect(init?.headers).toMatchObject({
+      Authorization: `Basic ${Buffer.from('github-client:github-secret').toString('base64')}`,
+    })
+    expect(init?.body).toBe(JSON.stringify({ access_token: 'access' }))
+  })
+
+  it('reports failures without exposing token values', async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => new Response(null, { status: 503 }))
+
+    const issues = await revokeOAuthGrants(
+      [{ providerId: 'google', accessToken: 'secret-token', refreshToken: null }],
+      {},
+      { fetch },
+    )
+
+    expect(issues).toEqual([
+      {
+        providerId: 'google',
+        reason: 'request-failed',
+        error: 'Unexpected HTTP status 503',
+      },
+    ])
+    expect(JSON.stringify(issues)).not.toContain('secret-token')
+  })
+})

--- a/apps/web/src/pages/PrivacyPolicy.tsx
+++ b/apps/web/src/pages/PrivacyPolicy.tsx
@@ -3,7 +3,7 @@ export const PrivacyPolicy = () => {
     <div className="flex items-center justify-center mx-auto bg-white/80 py-24">
       <article className="prose overflow-auto">
         <h1>Privacy Policy</h1>
-        <p>Last updated: 2024-11-23</p>
+        <p>Last updated: 2026-08-30</p>
 
         <h2>Introduction</h2>
         <p>
@@ -65,6 +65,18 @@ export const PrivacyPolicy = () => {
           We will retain your information only for as long as necessary to fulfill the purposes outlined in this Privacy
           Policy. We will retain and use your information to the extent necessary to comply with our legal obligations,
           resolve disputes, and enforce our policies.
+        </p>
+
+        <h2>Account Deletion</h2>
+        <p>
+          You can permanently delete your account from the account screen in the DXRating app. Deletion removes your
+          profile, comments, tags and tag attachments, aliases, sessions, passkeys, linked sign-in methods, and linked
+          LXNS credentials. Linked OAuth grants are revoked when supported by the provider. After deletion, you can
+          create a new account using the same email address or sign-in provider.
+        </p>
+        <p>
+          Account data is removed from our active systems immediately. Residual copies may remain in encrypted backups
+          until those backups are automatically deleted, or when retention is required by law.
         </p>
 
         <h2>Your Rights</h2>


### PR DESCRIPTION
## Summary

- enable Better Auth's permanent account-deletion endpoint
- delete account-owned profile, comments, tags, aliases, sessions, passkeys, OAuth links, LXNS credentials, and verification records
- revoke Apple, Google, and GitHub grants when provider tokens are available
- allow immediate registration with the same email or login method after deletion
- document deletion, backups, and limited legal-retention behavior in the privacy policy

External OAuth revocation is best-effort so a provider outage cannot prevent a user from deleting their DXRating account. The local OAuth link is always hard-deleted, and revocation failures are logged without token values.

Depends on #345.

## Validation

- `pnpm --filter @gekichumai/backend exec vitest run src/test/account-deletion-schema.test.ts src/test/account-deletion.test.ts src/test/oauth-revocation.test.ts` (7 tests passed)
- web client and SSR production builds passed
- backend type-check has one unchanged pre-existing `FlattenedSheet` error in `oneshot-renderer/index.tsx`

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>
