### PR TITLE
feat(seo): improve localized search and rating discovery

### DIFF
--- a/apps/web/src/components/rating/RatingIntroduction.tsx
+++ b/apps/web/src/components/rating/RatingIntroduction.tsx
@@ -1,0 +1,44 @@
+import { useTranslation } from 'react-i18next'
+
+export function RatingIntroduction() {
+  const { t } = useTranslation(['root'])
+
+  return (
+    <header className="flex-container !items-start !gap-3">
+      <h1 className="m-0 text-xl sm:text-2xl font-bold tracking-tight text-balance">
+        {t('root:pages.rating.heading')}
+      </h1>
+      <p className="m-0 max-w-3xl text-sm leading-relaxed text-zinc-600 text-pretty">
+        {t('root:pages.rating.introduction')}
+      </p>
+      <a
+        href="#rating-calculator"
+        className="inline-flex min-h-10 items-center text-blue-800 underline underline-offset-4 hover:text-blue-600"
+      >
+        {t('root:pages.rating.start')}
+      </a>
+      <details className="w-full text-sm">
+        <summary className="min-h-10 cursor-pointer py-2 font-semibold">{t('root:pages.rating.guide')}</summary>
+        <ol className="m-0 max-w-3xl pl-5 flex flex-col gap-3 leading-relaxed">
+          <li>
+            <h2 className="m-0 text-sm font-semibold">{t('root:pages.rating.import-heading')}</h2>
+            <p className="m-0 text-zinc-600">{t('root:pages.rating.import-description')}</p>
+          </li>
+          <li>
+            <h2 className="m-0 text-sm font-semibold">{t('root:pages.rating.calculate-heading')}</h2>
+            <p className="m-0 text-zinc-600">{t('root:pages.rating.calculate-description')}</p>
+          </li>
+          <li>
+            <h2 className="m-0 text-sm font-semibold">{t('root:pages.rating.share-heading')}</h2>
+            <p className="m-0 text-zinc-600">{t('root:pages.rating.share-description')}</p>
+          </li>
+        </ol>
+      </details>
+    </header>
+  )
+}
+
+export function RatingLoading() {
+  const { t } = useTranslation(['root'])
+  return <output className="flex-container text-sm text-zinc-600">{t('root:pages.rating.loading')}</output>
+}

--- a/apps/web/src/components/rating/__tests__/RatingIntroduction.test.tsx
+++ b/apps/web/src/components/rating/__tests__/RatingIntroduction.test.tsx
@@ -1,0 +1,27 @@
+import { renderToString } from 'react-dom/server'
+import { I18nextProvider } from 'react-i18next'
+import { describe, expect, it } from 'vitest'
+import { createServerI18n } from '@/setup/init-i18n'
+import { SUPPORTED_LOCALES } from '@/setup/locale'
+import { Route } from '@/routes/rating'
+
+describe('rating landing page SSR', () => {
+  it.each(SUPPORTED_LOCALES)('serves useful %s content before the calculator loads', (locale) => {
+    const i18n = createServerI18n(locale)
+    const Page = Route.options.component!
+    const html = renderToString(
+      <I18nextProvider i18n={i18n}>
+        <Page />
+      </I18nextProvider>,
+    )
+    const text = new DOMParser().parseFromString(html, 'text/html').body.textContent!
+    expect(text).toContain(i18n.t('root:pages.rating.heading'))
+    expect(text).toContain(i18n.t('root:pages.rating.import-description'))
+    expect(text).toContain(i18n.t('root:pages.rating.calculate-description'))
+    expect(text).toContain(i18n.t('root:pages.rating.share-description'))
+    expect(html).toContain('id="rating-calculator"')
+    expect(html).toContain('href="#rating-calculator"')
+    expect(html).toContain('<output')
+    expect(html).not.toContain('pages.rating.')
+  })
+})

--- a/apps/web/src/components/sheet/SearchIntroduction.tsx
+++ b/apps/web/src/components/sheet/SearchIntroduction.tsx
@@ -1,0 +1,69 @@
+import { DifficultyEnum, TypeEnum, dxdata } from '@gekichumai/dxdata'
+import { useTranslation } from 'react-i18next'
+import { toSupportedLocale } from '@/setup/locale'
+import { buildSheetPath } from './sheetLinks'
+
+// Start with songs already receiving search impressions; keep the catalog authoritative.
+const FEATURED_SONG_IDS = [
+  'Sky Trails',
+  'Latent Kingdom',
+  'クロノイデア',
+  '終焉逃避行',
+  '7 Wonders',
+  'Regulus',
+  'AiAe',
+  '雨露霜雪',
+  'CITRUS MONSTER',
+  'Break The Speakers',
+]
+
+export const featuredSearchCharts = FEATURED_SONG_IDS.flatMap((songId) => {
+  const song = dxdata.songs.find((song) => song.songId === songId)
+  const sheet = song?.sheets.find(
+    (sheet) =>
+      sheet.difficulty === DifficultyEnum.Master && (sheet.type === TypeEnum.DX || sheet.type === TypeEnum.STD),
+  )
+  return song && sheet ? [{ title: song.title, path: buildSheetPath({ songId, ...sheet }) }] : []
+})
+
+const linkClass =
+  'inline-flex min-h-10 items-center py-1 text-blue-800 underline underline-offset-4 hover:text-blue-600'
+
+export function SearchIntroduction() {
+  const { t, i18n } = useTranslation(['root'])
+  const locale = toSupportedLocale(i18n.language) ?? 'en'
+
+  return (
+    <header className="w-full flex flex-col gap-2">
+      <h1 className="m-0 text-xl sm:text-2xl font-bold tracking-tight text-balance">
+        {t('root:pages.search.heading')}
+      </h1>
+      <p className="m-0 max-w-3xl text-sm leading-relaxed text-zinc-600 text-pretty">
+        {t('root:pages.search.introduction')}
+      </p>
+      <nav aria-label={t('root:pages.search.explore')} className="flex flex-wrap gap-x-5">
+        <a className={linkClass} href={`/rating?locale=${locale}`}>
+          {t('root:pages.rating.heading')}
+        </a>
+        <a className={linkClass} href={`/charts/recent?locale=${locale}`}>
+          {t('root:pages.recent.title')}
+        </a>
+        <a className={linkClass} href={`/charts/trending?locale=${locale}`}>
+          {t('root:pages.trending.title')}
+        </a>
+      </nav>
+      <details className="text-sm">
+        <summary className="min-h-10 cursor-pointer py-2 font-semibold">{t('root:pages.search.featured')}</summary>
+        <ul className="m-0 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 list-none gap-x-5 p-0">
+          {featuredSearchCharts.map((chart) => (
+            <li key={chart.path}>
+              <a className={linkClass} href={`${chart.path}?locale=${locale}`}>
+                {chart.title}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </details>
+    </header>
+  )
+}

--- a/apps/web/src/components/sheet/__tests__/SearchIntroduction.test.tsx
+++ b/apps/web/src/components/sheet/__tests__/SearchIntroduction.test.tsx
@@ -1,0 +1,23 @@
+import { renderToString } from 'react-dom/server'
+import { I18nextProvider } from 'react-i18next'
+import { describe, expect, it } from 'vitest'
+import { createServerI18n } from '@/setup/init-i18n'
+import { SearchIntroduction, featuredSearchCharts } from '../SearchIntroduction'
+
+describe('search landing content', () => {
+  it('serves ten real song destinations and localized tool links without JavaScript', () => {
+    const i18n = createServerI18n('zh-Hant')
+    const html = renderToString(
+      <I18nextProvider i18n={i18n}>
+        <SearchIntroduction />
+      </I18nextProvider>,
+    )
+    expect(featuredSearchCharts).toHaveLength(10)
+    for (const chart of featuredSearchCharts) {
+      expect(html).toContain(`href="${chart.path}?locale=zh-Hant"`)
+    }
+    expect(html).toContain('href="/rating?locale=zh-Hant"')
+    expect(html).toContain('href="/charts/recent?locale=zh-Hant"')
+    expect(html).toContain(i18n.t('root:pages.search.heading'))
+  })
+})

--- a/apps/web/src/components/song/SongChartSummary.tsx
+++ b/apps/web/src/components/song/SongChartSummary.tsx
@@ -1,0 +1,50 @@
+import { useTranslation } from 'react-i18next'
+import { toSupportedLocale } from '@/setup/locale'
+import type { FlattenedSheet } from '@/songs'
+import { useAppContextDXDataVersion } from '@/models/context/useAppContext'
+import { getSheetTitleLabel } from './sheetDisplay'
+
+export function SongChartSummary({ sheet }: { sheet: FlattenedSheet }) {
+  const { t, i18n } = useTranslation(['song', 'sheet', 'root'])
+  const locale = toSupportedLocale(i18n.language) ?? 'en'
+  const version = useAppContextDXDataVersion()
+  const facts = [
+    { label: t('sheet:details.bpm'), value: sheet.bpm !== null && sheet.bpm > 0 ? sheet.bpm : null },
+    {
+      label: t('song:summary.internal-level'),
+      value: !sheet.isTypeUtage && sheet.internalLevelValue > 0 ? sheet.internalLevelValue.toFixed(1) : null,
+    },
+    { label: t('song:summary.version'), value: version },
+    {
+      label: t('sheet:details.regional-availability'),
+      value: Object.entries(sheet.regions)
+        .filter(([, available]) => available)
+        .map(([region]) => region.toUpperCase())
+        .join(' · '),
+    },
+  ].filter((fact) => fact.value !== null && fact.value !== '')
+
+  return (
+    <section aria-label={t('song:summary.title')} className="flex flex-col gap-2">
+      <p className="m-0 text-sm leading-relaxed text-zinc-600">
+        {t('song:summary.description', { title: sheet.title, chart: getSheetTitleLabel(sheet, locale) })}
+      </p>
+      <dl className="m-0 flex flex-wrap gap-x-6 gap-y-2 text-sm">
+        {facts.map(({ label, value }) => (
+          <div key={label}>
+            <dt className="text-xs text-zinc-500">{label}</dt>
+            <dd className="m-0 font-semibold tabular-nums">{value}</dd>
+          </div>
+        ))}
+      </dl>
+      {!sheet.isTypeUtage && (
+        <a
+          className="inline-flex self-start min-h-10 items-center text-sm text-blue-800 underline underline-offset-4"
+          href={`/rating?locale=${locale}`}
+        >
+          {t('root:pages.rating.heading')}
+        </a>
+      )}
+    </section>
+  )
+}

--- a/apps/web/src/components/song/SongHeader.tsx
+++ b/apps/web/src/components/song/SongHeader.tsx
@@ -59,7 +59,7 @@ export const SongHeader: FC<{ sheet: FlattenedSheet }> = ({ sheet }) => {
 
         <div className="flex flex-col gap-1 flex-1 min-w-0">
           <h1
-            className="text-xl font-bold leading-tight cursor-pointer truncate"
+            className="text-xl font-bold leading-tight cursor-pointer break-words text-balance"
             onClick={() => {
               navigator.clipboard.writeText(song.title)
               toast.success(t('sheet:copy-title.toast-success'), { id: `copy-song-title-${song.songId}` })

--- a/apps/web/src/components/song/SongSheetTabs.tsx
+++ b/apps/web/src/components/song/SongSheetTabs.tsx
@@ -1,12 +1,15 @@
 import { type DifficultyEnum, type Sheet, TypeEnum } from '@gekichumai/dxdata'
 import { Tab, Tabs } from '@mui/material'
-import { type FC, useMemo } from 'react'
+import { type FC, type MouseEvent, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { DIFFICULTIES } from '../../models/difficulties'
-import { DIFFICULTY_ORDER } from '../../models/constants'
+import { DIFFICULTY_ORDER, getHighestDifficulty } from '../../models/constants'
+import { buildSheetPath } from '../sheet/sheetLinks'
+import { toSupportedLocale } from '@/setup/locale'
 import { getSheetTypeAltTextKey, SHEET_TYPE_TAB_IMAGES } from '../sheet/sheetTypeAssets'
 
 export interface SongSheetTabsProps {
+  songId: string
   sheets: Sheet[]
   availableTypes: readonly TypeEnum[]
   activeType: TypeEnum
@@ -32,6 +35,7 @@ const renderTypeTabLabel = (type: TypeEnum, label: string, altText: string) => {
 }
 
 export const SongSheetTabs: FC<SongSheetTabsProps> = ({
+  songId,
   sheets,
   availableTypes,
   activeType,
@@ -39,7 +43,13 @@ export const SongSheetTabs: FC<SongSheetTabsProps> = ({
   onTypeChange,
   onDifficultyChange,
 }) => {
-  const { t } = useTranslation(['song', 'sheet'])
+  const { t, i18n } = useTranslation(['song', 'sheet'])
+  const locale = toSupportedLocale(i18n.language) ?? 'en'
+  const handleNavigation = (event: MouseEvent, navigate: () => void) => {
+    if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return
+    event.preventDefault()
+    navigate()
+  }
 
   const difficultiesForActiveType = useMemo(() => {
     const diffSet = new Set(sheets.filter((s) => s.type === activeType).map((s) => s.difficulty))
@@ -50,7 +60,6 @@ export const SongSheetTabs: FC<SongSheetTabsProps> = ({
     <div className="flex flex-col gap-1">
       <Tabs
         value={activeType}
-        onChange={(_, v) => onTypeChange(v)}
         variant="scrollable"
         scrollButtons="auto"
         classes={{
@@ -64,6 +73,9 @@ export const SongSheetTabs: FC<SongSheetTabsProps> = ({
           return (
             <Tab
               key={type}
+              component="a"
+              href={`${buildSheetPath({ songId, type, difficulty: getHighestDifficulty(sheets.filter((sheet) => sheet.type === type)) })}?locale=${locale}`}
+              onClick={(event) => handleNavigation(event, () => onTypeChange(type))}
               value={type}
               label={renderTypeTabLabel(type, label, altText)}
               classes={{
@@ -77,7 +89,6 @@ export const SongSheetTabs: FC<SongSheetTabsProps> = ({
 
       <Tabs
         value={activeDifficulty}
-        onChange={(_, v) => onDifficultyChange(v)}
         variant="scrollable"
         scrollButtons="auto"
         classes={{
@@ -94,6 +105,9 @@ export const SongSheetTabs: FC<SongSheetTabsProps> = ({
           return (
             <Tab
               key={difficulty}
+              component="a"
+              href={`${buildSheetPath({ songId, type: activeType, difficulty })}?locale=${locale}`}
+              onClick={(event) => handleNavigation(event, () => onDifficultyChange(difficulty))}
               value={difficulty}
               label={config.title}
               classes={{

--- a/apps/web/src/components/song/__tests__/SongSheetTabs.test.tsx
+++ b/apps/web/src/components/song/__tests__/SongSheetTabs.test.tsx
@@ -1,5 +1,5 @@
 import { type Sheet, DifficultyEnum, TypeEnum, VersionEnum } from '@gekichumai/dxdata'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import i18n from 'i18next'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { initI18n } from '@/setup/init-i18n'
@@ -42,6 +42,7 @@ describe('SongSheetTabs', () => {
   it('uses descriptive type image alt text for DX and Standard tabs with text fallback for other types', () => {
     render(
       <SongSheetTabs
+        songId="test-song"
         sheets={[
           makeSheet(TypeEnum.DX),
           makeSheet(TypeEnum.STD),
@@ -72,6 +73,7 @@ describe('SongSheetTabs', () => {
 
     render(
       <SongSheetTabs
+        songId="test-song"
         sheets={[makeSheet(TypeEnum.DX)]}
         availableTypes={[TypeEnum.DX]}
         activeType={TypeEnum.DX}
@@ -82,5 +84,26 @@ describe('SongSheetTabs', () => {
     )
 
     expect(screen.getByRole('img', { name: 'でらっくす譜面' })).toBeTruthy()
+  })
+
+  it('exposes encoded difficulty links and preserves modified-click navigation', () => {
+    const onDifficultyChange = vi.fn()
+    render(
+      <SongSheetTabs
+        songId="a/b & c"
+        sheets={[makeSheet(TypeEnum.DX)]}
+        availableTypes={[TypeEnum.DX]}
+        activeType={TypeEnum.DX}
+        activeDifficulty={DifficultyEnum.Master}
+        onTypeChange={vi.fn()}
+        onDifficultyChange={onDifficultyChange}
+      />,
+    )
+    const tab = screen.getByRole('tab', { name: 'MASTER' })
+    expect(tab.getAttribute('href')).toBe('/songs/a%2Fb%20%26%20c/dx/master?locale=en')
+    fireEvent.click(tab, { ctrlKey: true })
+    expect(onDifficultyChange).not.toHaveBeenCalled()
+    fireEvent.click(tab)
+    expect(onDifficultyChange).toHaveBeenCalledWith(DifficultyEnum.Master)
   })
 })

--- a/apps/web/src/components/song/__tests__/sheetDisplay.test.ts
+++ b/apps/web/src/components/song/__tests__/sheetDisplay.test.ts
@@ -9,7 +9,7 @@ describe('sheet display labels', () => {
     expect(getSheetTitleLabel({ type: TypeEnum.UTAGE, difficulty: '【協】' })).toBe('Utage 【協】')
     expect(getSheetTitleLabel({ type: TypeEnum.UTAGE2P, difficulty: '【協】' })).toBe('Buddy 【協】')
     expect(getSheetPageTitle({ title: 'Song Title' }, { type: TypeEnum.DX, difficulty: DifficultyEnum.ReMaster })).toBe(
-      'Song Title [DX Re:MASTER] - DXRating',
+      'Song Title [DX Re:MASTER] - maimai - DXRating',
     )
   })
 

--- a/apps/web/src/components/song/sheetDisplay.ts
+++ b/apps/web/src/components/song/sheetDisplay.ts
@@ -61,5 +61,5 @@ export function getSheetPageTitle(
   },
   locale: SupportedLocale = 'en',
 ) {
-  return `${song.title} [${getSheetTitleLabel(sheet, locale)}] - DXRating`
+  return `${song.title} [${getSheetTitleLabel(sheet, locale)}] - maimai - DXRating`
 }

--- a/apps/web/src/locales/resources/en.json
+++ b/apps/web/src/locales/resources/en.json
@@ -1,8 +1,8 @@
 {
   "root": {
     "pages.search.title": "Search Charts",
-    "pages.search.seo-title": "Charts & Songs",
-    "pages.search.seo-description": "Browse all maimai DX charts by song title, artist, or difficulty. View internal levels, note counts, and detailed chart information.",
+    "pages.search.seo-title": "maimai Songs & Chart Constants",
+    "pages.search.seo-description": "Find songs by title, artist, or alias. Compare chart constants, BPM, note counts, and difficulties, or calculate your rating and Best 50.",
     "pages.recent.title": "Recently Updated",
     "pages.recent.seo-title": "Recently Updated Charts",
     "pages.recent.seo-description": "Discover recently updated maimai DX chart pages on DXRating, excluding BASIC and ADVANCED charts.",
@@ -12,8 +12,8 @@
     "pages.trending.seo-description": "Discover maimai DX chart pages currently getting the most attention on DXRating.",
     "pages.trending.icon-label": "Trending charts",
     "pages.rating.title": "My Rating",
-    "pages.rating.seo-title": "Rating Calculator",
-    "pages.rating.seo-description": "Calculate and manage your maimai DX rating records, Best 50 entries, achievements, and score details on DXRating.",
+    "pages.rating.seo-title": "maimai Rating Calculator & Best 50",
+    "pages.rating.seo-description": "Import your scores or add achievements to calculate your maimai DX rating, review your Best 50, and create a share image.",
     "seo.description": "DXRating is a maimai DX Rating analyzer, along with other features like chart details and more.",
     "seo.keywords": "maimai, maimai DX, maimai DX Rating, maimai DX Rating analyzer, gekichumai, maimai derakkusu, chart details, rating calculator, maimai wiki",
     "share.copy-succeeded": "Copied to clipboard",
@@ -22,7 +22,22 @@
     "external-links.github": "Open DXRating on GitHub",
     "not-found.title": "Page Not Found",
     "not-found.description": "This page may have moved, or the link may be outdated.",
-    "not-found.back-to-home": "Back to Home"
+    "not-found.back-to-home": "Back to Home",
+    "pages.search.heading": "Search maimai songs and charts",
+    "pages.search.introduction": "Find songs by title, artist, or alias. Compare chart constants, BPM, note counts, and difficulties, or calculate your rating and Best 50.",
+    "pages.search.explore": "Explore maimai tools",
+    "pages.search.featured": "Explore song details",
+    "pages.rating.heading": "maimai Rating Calculator & Best 50",
+    "pages.rating.introduction": "Import your scores or add achievements to calculate your maimai DX rating, review your Best 50, and create a share image.",
+    "pages.rating.start": "Go to the calculator",
+    "pages.rating.guide": "How to calculate and share your Best 50",
+    "pages.rating.import-heading": "Add or import scores",
+    "pages.rating.import-description": "Add a song and achievement manually, or use Import to load records from MaimaiNET, Diving Fish, LXNS, or a supported file.",
+    "pages.rating.calculate-heading": "Understand your rating",
+    "pages.rating.calculate-description": "Each chart contributes rating based on its chart constant and your achievement. Best 50 combines your best 15 current-version charts and 35 older charts. Select the correct game version and region above.",
+    "pages.rating.share-heading": "Share your Best 50",
+    "pages.rating.share-description": "Use the image button to create a Best 50 share image. Export saves your records as JSON so you can import them again later.",
+    "pages.rating.loading": "Loading the calculator…"
   },
   "settings": {
     "version-and-region.select": "Select DXData Version and Region",
@@ -144,7 +159,12 @@
     "type.std": "Standard",
     "type.utage": "Utage",
     "type.utage2p": "Buddy",
-    "seo.description": "{{title}} by {{artist}} - {{sheetLabel}} chart details, internal levels, and note counts on DXRating."
+    "seo.description": "{{title}} by {{artist}} — maimai {{sheetLabel}} chart constants, note counts, and rating information.",
+    "summary.title": "Chart at a glance",
+    "summary.description": "{{title}} in maimai — {{chart}} chart information.",
+    "summary.internal-level": "Chart constant",
+    "summary.version": "Selected version",
+    "seo.bpm": "{{bpm}} BPM."
   },
   "about": {
     "title": "About",

--- a/apps/web/src/locales/resources/ja.json
+++ b/apps/web/src/locales/resources/ja.json
@@ -1,8 +1,8 @@
 {
   "root": {
     "pages.search.title": "譜面検索",
-    "pages.search.seo-title": "譜面検索",
-    "pages.search.seo-description": "maimai DX の譜面を、楽曲名、アーティスト、難易度から検索できます。譜面定数、ノーツ数、詳しい譜面情報も確認できます。",
+    "pages.search.seo-title": "maimai 楽曲・譜面定数検索",
+    "pages.search.seo-description": "曲名・アーティスト・別名から楽曲を検索。譜面定数、BPM、ノーツ数、難易度を確認したり、レーティングや Best 50 を計算したりできます。",
     "pages.recent.title": "最近更新",
     "pages.recent.seo-title": "最近更新された譜面",
     "pages.recent.seo-description": "DXRating で BASIC と ADVANCED を除く、最近更新された maimai DX 譜面ページを確認できます。",
@@ -12,8 +12,8 @@
     "pages.trending.seo-description": "DXRating で現在よく見られている maimai DX 譜面ページを確認できます。",
     "pages.trending.icon-label": "トレンド譜面",
     "pages.rating.title": "レーテイング計算",
-    "pages.rating.seo-title": "レーティング計算",
-    "pages.rating.seo-description": "maimai DX のレーティング記録、Best 50、達成率、スコア詳細を DXRating で計算・管理できます。",
+    "pages.rating.seo-title": "maimai レーティング計算・Best 50",
+    "pages.rating.seo-description": "スコアのインポートや達成率の入力で、maimai でらっくすのレーティングを計算。Best 50 の確認や共有画像の作成もできます。",
     "seo.description": "DXRating は maimai DX Rating の分析ツールです。譜面詳細などの機能も提供しています。",
     "seo.keywords": "maimai, maimai DX, maimai DX Rating, maimai DX Rating 分析, ゲキチュウマイ, maimaiでらっくす, 譜面情報, レーティング計算, maimai wiki",
     "share.copy-content": "{{ link }}",
@@ -22,7 +22,22 @@
     "external-links.github": "DXRating を GitHub で開く",
     "not-found.title": "ページが見つかりません",
     "not-found.description": "ページが移動したか、リンクが古くなっている可能性があります。",
-    "not-found.back-to-home": "ホームに戻る"
+    "not-found.back-to-home": "ホームに戻る",
+    "pages.search.heading": "maimai 楽曲・譜面検索",
+    "pages.search.introduction": "曲名・アーティスト・別名から楽曲を検索。譜面定数、BPM、ノーツ数、難易度を確認したり、レーティングや Best 50 を計算したりできます。",
+    "pages.search.explore": "maimai のツール",
+    "pages.search.featured": "楽曲の詳細を見る",
+    "pages.rating.heading": "maimai レーティング計算・Best 50",
+    "pages.rating.introduction": "スコアのインポートや達成率の入力で、maimai でらっくすのレーティングを計算。Best 50 の確認や共有画像の作成もできます。",
+    "pages.rating.start": "計算ツールへ",
+    "pages.rating.guide": "Best 50 の計算・共有方法",
+    "pages.rating.import-heading": "スコアを追加・インポート",
+    "pages.rating.import-description": "楽曲と達成率を手動で追加するか、「インポート」から MaimaiNET、Diving Fish、LXNS、対応ファイルの記録を読み込みます。",
+    "pages.rating.calculate-heading": "レーティングの仕組み",
+    "pages.rating.calculate-description": "各譜面のレーティングは譜面定数と達成率で決まります。Best 50 は現行バージョンの上位15譜面と旧曲の上位35譜面で構成されます。上部でプレイするバージョンと地域を選んでください。",
+    "pages.rating.share-heading": "Best 50 を共有",
+    "pages.rating.share-description": "画像ボタンから Best 50 の共有画像を作成できます。「エクスポート」では記録を JSON ファイルに保存し、後から再インポートできます。",
+    "pages.rating.loading": "計算ツールを読み込み中…"
   },
   "settings": {
     "region.title": "地域：{{region}}",
@@ -144,7 +159,12 @@
     "type.std": "スタンダード",
     "type.utage": "宴",
     "type.utage2p": "バディ",
-    "seo.description": "{{title}} / {{artist}} - {{sheetLabel}} の譜面詳細、譜面定数、ノーツ数 - DXRating。"
+    "seo.description": "{{title}} / {{artist}} — maimai {{sheetLabel}} の譜面定数、ノーツ数、レーティング情報。",
+    "summary.title": "譜面の概要",
+    "summary.description": "maimai「{{title}}」の {{chart}} 譜面情報。",
+    "summary.internal-level": "譜面定数",
+    "summary.version": "選択中のバージョン",
+    "seo.bpm": "BPM {{bpm}}。"
   },
   "about": {
     "title": "当サイトについて",

--- a/apps/web/src/locales/resources/ko.json
+++ b/apps/web/src/locales/resources/ko.json
@@ -1,8 +1,8 @@
 {
   "root": {
     "pages.search.title": "채보 검색",
-    "pages.search.seo-title": "채보 및 곡",
-    "pages.search.seo-description": "곡명, 아티스트 또는 난이도로 모든 maimai DX 채보를 검색하세요. 내부 레벨, 노트 수와 상세 채보 정보를 확인할 수 있습니다.",
+    "pages.search.seo-title": "maimai 곡・채보 상수 검색",
+    "pages.search.seo-description": "곡명, 아티스트, 별명으로 검색하세요. 채보 상수, BPM, 노트 수와 난이도를 확인하고 레이팅과 Best 50을 계산할 수 있어요.",
     "pages.recent.title": "최근 업데이트",
     "pages.recent.seo-title": "최근 업데이트된 채보",
     "pages.recent.seo-description": "BASIC과 ADVANCED를 제외하고 최근 업데이트된 maimai DX 채보 페이지를 DXRating에서 확인하세요.",
@@ -12,8 +12,8 @@
     "pages.trending.seo-description": "현재 DXRating에서 가장 많은 관심을 받는 maimai DX 채보 페이지를 확인하세요.",
     "pages.trending.icon-label": "인기 채보",
     "pages.rating.title": "내 Rating",
-    "pages.rating.seo-title": "Rating 계산기",
-    "pages.rating.seo-description": "DXRating에서 maimai DX Rating 기록, Best 50 항목, 달성률과 점수 상세 정보를 계산하고 관리하세요.",
+    "pages.rating.seo-title": "maimai 레이팅 계산기 & Best 50",
+    "pages.rating.seo-description": "스코어를 가져오거나 달성률을 입력해 maimai DX 레이팅을 계산하고, Best 50을 확인하고 공유 이미지를 만들 수 있어요.",
     "seo.description": "DXRating은 채보 상세 정보 등 다양한 기능을 제공하는 maimai DX Rating 분석 도구입니다.",
     "seo.keywords": "maimai, maimai DX, maimai DX Rating, maimai DX Rating 분석, gekichumai, maimai derakkusu, 채보 정보, Rating 계산기, maimai 위키",
     "share.copy-succeeded": "클립보드에 복사했습니다",
@@ -22,7 +22,22 @@
     "external-links.github": "GitHub에서 DXRating 열기",
     "not-found.title": "페이지를 찾을 수 없습니다",
     "not-found.description": "페이지가 이동했거나 링크가 오래되었을 수 있습니다.",
-    "not-found.back-to-home": "홈으로 돌아가기"
+    "not-found.back-to-home": "홈으로 돌아가기",
+    "pages.search.heading": "maimai 곡과 채보 검색",
+    "pages.search.introduction": "곡명, 아티스트, 별명으로 검색하세요. 채보 상수, BPM, 노트 수와 난이도를 확인하고 레이팅과 Best 50을 계산할 수 있어요.",
+    "pages.search.explore": "maimai 도구",
+    "pages.search.featured": "곡 정보 살펴보기",
+    "pages.rating.heading": "maimai 레이팅 계산기 & Best 50",
+    "pages.rating.introduction": "스코어를 가져오거나 달성률을 입력해 maimai DX 레이팅을 계산하고, Best 50을 확인하고 공유 이미지를 만들 수 있어요.",
+    "pages.rating.start": "계산기로 이동",
+    "pages.rating.guide": "Best 50 계산 및 공유 방법",
+    "pages.rating.import-heading": "스코어 추가 또는 가져오기",
+    "pages.rating.import-description": "곡과 달성률을 직접 추가하거나 가져오기 메뉴에서 MaimaiNET, Diving Fish, LXNS 또는 지원하는 파일의 기록을 불러오세요.",
+    "pages.rating.calculate-heading": "레이팅 계산 방식",
+    "pages.rating.calculate-description": "각 채보의 레이팅은 채보 상수와 달성률로 계산돼요. Best 50은 현재 버전의 상위 15개 채보와 이전 버전의 상위 35개 채보로 구성돼요. 위에서 게임 버전과 지역을 선택하세요.",
+    "pages.rating.share-heading": "Best 50 공유",
+    "pages.rating.share-description": "이미지 버튼으로 Best 50 공유 이미지를 만들 수 있어요. 내보내기로 기록을 JSON 파일에 저장하면 나중에 다시 가져올 수 있어요.",
+    "pages.rating.loading": "계산기를 불러오는 중…"
   },
   "settings": {
     "version-and-region.select": "DXData 버전 및 지역 선택",
@@ -144,7 +159,12 @@
     "type.std": "스탠다드",
     "type.utage": "宴会場",
     "type.utage2p": "버디",
-    "seo.description": "{{artist}}의 {{title}} - DXRating에서 {{sheetLabel}} 채보 상세 정보, 내부 레벨과 노트 수를 확인하세요."
+    "seo.description": "{{title}} / {{artist}} — maimai {{sheetLabel}} 채보 상수, 노트 수, 레이팅 정보.",
+    "summary.title": "채보 요약",
+    "summary.description": "maimai의 {{title}} — {{chart}} 채보 정보.",
+    "summary.internal-level": "채보 상수",
+    "summary.version": "선택한 버전",
+    "seo.bpm": "{{bpm}} BPM."
   },
   "about": {
     "title": "정보",

--- a/apps/web/src/locales/resources/zh-Hans.json
+++ b/apps/web/src/locales/resources/zh-Hans.json
@@ -1,8 +1,8 @@
 {
   "root": {
     "pages.search.title": "搜索谱面",
-    "pages.search.seo-title": "搜索谱面",
-    "pages.search.seo-description": "按歌曲名、艺术家或难度浏览所有 maimai DX 谱面，查看谱面定数、音符数和详细谱面信息。",
+    "pages.search.seo-title": "maimai 乐曲与谱面定数查询",
+    "pages.search.seo-description": "按曲名、作曲家或别名搜索，查看谱面定数、BPM、音符数和难度，也可以计算 Rating 和 Best 50。",
     "pages.recent.title": "最近更新",
     "pages.recent.seo-title": "最近更新的谱面",
     "pages.recent.seo-description": "在 DXRating 查看最近更新的 maimai DX 谱面页面，不含 BASIC 与 ADVANCED 谱面。",
@@ -12,8 +12,8 @@
     "pages.trending.seo-description": "在 DXRating 查看当前最受关注的 maimai DX 谱面页面。",
     "pages.trending.icon-label": "热门趋势谱面",
     "pages.rating.title": "计算评分",
-    "pages.rating.seo-title": "评分计算器",
-    "pages.rating.seo-description": "在 DXRating 计算和管理你的 maimai DX Rating 记录、Best 50、达成率和分数详情。",
+    "pages.rating.seo-title": "maimai Rating 计算器与 Best 50",
+    "pages.rating.seo-description": "导入成绩或手动输入达成率，计算 maimai DX Rating、查看 Best 50，并生成分享图片。",
     "seo.description": "DXRating 是 maimai DX Rating 分析工具，也提供谱面详情等功能。",
     "seo.keywords": "maimai, maimai DX, maimai DX Rating, maimai DX Rating 分析工具, 中二节奏, 舞萌, 舞萌DX, 谱面详情, 评分计算器, maimai wiki",
     "share.copy-content": "{{ link }}",
@@ -22,7 +22,22 @@
     "external-links.github": "在 GitHub 打开 DXRating",
     "not-found.title": "页面未找到",
     "not-found.description": "页面可能已移动，或链接已经过期。",
-    "not-found.back-to-home": "返回首页"
+    "not-found.back-to-home": "返回首页",
+    "pages.search.heading": "maimai 乐曲与谱面查询",
+    "pages.search.introduction": "按曲名、作曲家或别名搜索，查看谱面定数、BPM、音符数和难度，也可以计算 Rating 和 Best 50。",
+    "pages.search.explore": "maimai 工具",
+    "pages.search.featured": "查看乐曲详情",
+    "pages.rating.heading": "maimai Rating 计算器与 Best 50",
+    "pages.rating.introduction": "导入成绩或手动输入达成率，计算 maimai DX Rating、查看 Best 50，并生成分享图片。",
+    "pages.rating.start": "前往计算器",
+    "pages.rating.guide": "如何计算和分享 Best 50",
+    "pages.rating.import-heading": "添加或导入成绩",
+    "pages.rating.import-description": "手动添加乐曲和达成率，或使用「导入」从 MaimaiNET、水鱼、落雪及支持的文件中导入成绩。",
+    "pages.rating.calculate-heading": "了解 Rating 的计算方式",
+    "pages.rating.calculate-description": "单曲 Rating 由谱面定数和达成率决定。Best 50 由当前版本的前 15 个谱面和旧曲的前 35 个谱面组成。请先在上方选择对应的游戏版本和地区。",
+    "pages.rating.share-heading": "分享 Best 50",
+    "pages.rating.share-description": "使用图片按钮生成 Best 50 分享图。「导出」可将成绩保存为 JSON 文件，方便日后重新导入。",
+    "pages.rating.loading": "正在加载计算器…"
   },
   "settings": {
     "region.title": "服务器：{{region}}",
@@ -144,7 +159,12 @@
     "type.std": "标准",
     "type.utage": "宴",
     "type.utage2p": "Buddy",
-    "seo.description": "{{title}} / {{artist}} - {{sheetLabel}} 谱面详情、谱面定数与音符数 - DXRating。"
+    "seo.description": "{{title}} / {{artist}} — maimai {{sheetLabel}} 谱面定数、音符数与 Rating 信息。",
+    "summary.title": "谱面概览",
+    "summary.description": "maimai「{{title}}」的 {{chart}} 谱面信息。",
+    "summary.internal-level": "谱面定数",
+    "summary.version": "当前选择的版本",
+    "seo.bpm": "BPM {{bpm}}。"
   },
   "about": {
     "title": "关于本站",

--- a/apps/web/src/locales/resources/zh-Hant.json
+++ b/apps/web/src/locales/resources/zh-Hant.json
@@ -1,8 +1,8 @@
 {
   "root": {
     "pages.search.title": "搜尋譜面",
-    "pages.search.seo-title": "搜尋譜面",
-    "pages.search.seo-description": "按歌曲名、藝術家或難度瀏覽所有 maimai DX 譜面，查看譜面定數、音符數和詳細譜面資訊。",
+    "pages.search.seo-title": "maimai 樂曲與譜面定數查詢",
+    "pages.search.seo-description": "依曲名、作曲家或別名搜尋，查看譜面定數、BPM、音符數和難度，也可以計算 Rating 和 Best 50。",
     "pages.recent.title": "最近更新",
     "pages.recent.seo-title": "最近更新的譜面",
     "pages.recent.seo-description": "在 DXRating 查看最近更新的 maimai DX 譜面頁面，不含 BASIC 與 ADVANCED 譜面。",
@@ -12,8 +12,8 @@
     "pages.trending.seo-description": "在 DXRating 查看目前最受關注的 maimai DX 譜面頁面。",
     "pages.trending.icon-label": "熱門趨勢譜面",
     "pages.rating.title": "計算評分",
-    "pages.rating.seo-title": "評分計算器",
-    "pages.rating.seo-description": "在 DXRating 計算和管理你的 maimai DX Rating 記錄、Best 50、達成率和分數詳情。",
+    "pages.rating.seo-title": "maimai Rating 計算器與 Best 50",
+    "pages.rating.seo-description": "匯入成績或手動輸入達成率，計算 maimai DX Rating、查看 Best 50，並產生分享圖片。",
     "seo.description": "DXRating 是 maimai DX Rating 分析工具，也提供譜面詳情等功能。",
     "seo.keywords": "maimai, maimai DX, maimai DX Rating, maimai DX Rating 分析工具, 中二節奏, 舞萌, 舞萌DX, 譜面詳情, 評分計算器, maimai wiki",
     "share.copy-content": "{{ link }}",
@@ -22,7 +22,22 @@
     "external-links.github": "在 GitHub 開啟 DXRating",
     "not-found.title": "找不到頁面",
     "not-found.description": "頁面可能已移動，或連結已經過期。",
-    "not-found.back-to-home": "返回首頁"
+    "not-found.back-to-home": "返回首頁",
+    "pages.search.heading": "maimai 樂曲與譜面查詢",
+    "pages.search.introduction": "依曲名、作曲家或別名搜尋，查看譜面定數、BPM、音符數和難度，也可以計算 Rating 和 Best 50。",
+    "pages.search.explore": "maimai 工具",
+    "pages.search.featured": "查看樂曲詳情",
+    "pages.rating.heading": "maimai Rating 計算器與 Best 50",
+    "pages.rating.introduction": "匯入成績或手動輸入達成率，計算 maimai DX Rating、查看 Best 50，並產生分享圖片。",
+    "pages.rating.start": "前往計算器",
+    "pages.rating.guide": "如何計算及分享 Best 50",
+    "pages.rating.import-heading": "新增或匯入成績",
+    "pages.rating.import-description": "手動新增樂曲與達成率，或使用「匯入」從 MaimaiNET、水魚、落雪及支援的檔案中匯入成績。",
+    "pages.rating.calculate-heading": "了解 Rating 的計算方式",
+    "pages.rating.calculate-description": "單曲 Rating 由譜面定數與達成率決定。Best 50 由目前版本的前 15 個譜面及舊曲的前 35 個譜面組成。請先在上方選擇對應的遊戲版本與地區。",
+    "pages.rating.share-heading": "分享 Best 50",
+    "pages.rating.share-description": "使用圖片按鈕產生 Best 50 分享圖。「匯出」可將成績儲存為 JSON 檔案，方便日後重新匯入。",
+    "pages.rating.loading": "正在載入計算器…"
   },
   "settings": {
     "region.title": "伺服器：{{region}}",
@@ -144,7 +159,12 @@
     "type.std": "標準",
     "type.utage": "宴",
     "type.utage2p": "Buddy",
-    "seo.description": "{{title}} / {{artist}} - {{sheetLabel}} 譜面詳情、譜面定數與音符數 - DXRating。"
+    "seo.description": "{{title}} / {{artist}} — maimai {{sheetLabel}} 譜面定數、音符數與 Rating 資訊。",
+    "summary.title": "譜面概覽",
+    "summary.description": "maimai「{{title}}」的 {{chart}} 譜面資訊。",
+    "summary.internal-level": "譜面定數",
+    "summary.version": "目前選擇的版本",
+    "seo.bpm": "BPM {{bpm}}。"
   },
   "about": {
     "title": "關於本站",

--- a/apps/web/src/pages/RatingCalculator.tsx
+++ b/apps/web/src/pages/RatingCalculator.tsx
@@ -50,6 +50,7 @@ import {
   type SyncFlag,
 } from '../components/rating/RatingCalculatorAddEntryForm'
 import { RatingCalculatorStatistics } from '../components/rating/RatingCalculatorStatistics'
+import { RatingLoading } from '../components/rating/RatingIntroduction'
 import { ClearButton } from '../components/rating/io/ClearButton'
 import { ExportMenu } from '../components/rating/io/ExportMenu'
 import { ImportMenu } from '../components/rating/io/ImportMenu'
@@ -163,7 +164,7 @@ export const RatingCalculator = () => {
     [allEntries, modifyEntries, sheets],
   )
 
-  if (!sheets) return null
+  if (!sheets) return <RatingLoading />
 
   return (
     <div className="flex-container w-full pb-global">

--- a/apps/web/src/pages/SheetList.tsx
+++ b/apps/web/src/pages/SheetList.tsx
@@ -9,6 +9,7 @@ import IconMdiClose from '~icons/mdi/close'
 import MdiIconInfo from '~icons/mdi/information'
 import { ResponsiveDialog } from '../components/global/ResponsiveDialog'
 import { SearchQuerySeedList } from '../components/sheet/SearchQuerySeedList'
+import { SearchIntroduction } from '../components/sheet/SearchIntroduction'
 import type { SearchQuerySeedSheet } from '../components/sheet/searchQuerySeed'
 import { SheetDialogContent } from '../components/sheet/SheetDialogContent'
 import { SheetListContainer } from '../components/sheet/SheetListContainer'
@@ -270,6 +271,7 @@ const SheetListInnerContent: FC<{ search: SearchParams; seedSheets: readonly Sea
         />
       )}
       <div className="flex-container pb-global">
+        {!inputQuery && <SearchIntroduction />}
         <ResponsiveDialog
           open={!!activeSheet}
           setOpen={(open) => {

--- a/apps/web/src/pages/SongPage.tsx
+++ b/apps/web/src/pages/SongPage.tsx
@@ -2,6 +2,7 @@ import { DifficultyEnum, TypeEnum, dxdata } from '@gekichumai/dxdata'
 import { IconButton } from '@mui/material'
 import { type FC, useMemo } from 'react'
 import { getRouteApi, useNavigate } from '@tanstack/react-router'
+import { useTranslation } from 'react-i18next'
 import MdiArrowLeft from '~icons/mdi/arrow-left'
 import { NotFoundContent } from '@/components/global/NotFoundContent'
 import { TYPE_ORDER, getHighestDifficulty } from '../models/constants'
@@ -9,16 +10,20 @@ import { useAppContextDXDataVersion } from '../models/context/useAppContext'
 import { useServerAliases } from '../models/useServerAliases'
 import { type FlattenedSheet, canonicalId, getSearchAcronymsWithServerAliases } from '../songs'
 import { SongHeader } from '../components/song/SongHeader'
+import { SongChartSummary } from '../components/song/SongChartSummary'
 import { SongSheetContent } from '../components/song/SongSheetContent'
 import { SongSheetTabs } from '../components/song/SongSheetTabs'
 import { sheetReleaseDateTimestamp } from '../utils/dateFormatting'
 import { getVisibleSongPageSheets } from './songPageSheets'
+import { toSupportedLocale } from '@/setup/locale'
 
 const routeApi = getRouteApi('/songs/$songId/$type/$difficulty')
 
 export const SongPage: FC = () => {
   const { songId, type, difficulty } = routeApi.useParams()
   const navigate = useNavigate()
+  const { i18n } = useTranslation()
+  const locale = toSupportedLocale(i18n.language) ?? 'en'
   const appVersion = useAppContextDXDataVersion()
   const { data: serverAliases } = useServerAliases()
 
@@ -75,6 +80,7 @@ export const SongPage: FC = () => {
     const sheetsOfType = flattenedSheets.filter((s) => s.type === newType)
     navigate({
       to: '/songs/$songId/$type/$difficulty',
+      search: () => ({ locale }),
       params: {
         songId,
         type: newType,
@@ -86,6 +92,7 @@ export const SongPage: FC = () => {
   const handleDifficultyChange = (newDifficulty: DifficultyEnum) => {
     navigate({
       to: '/songs/$songId/$type/$difficulty',
+      search: () => ({ locale }),
       params: {
         songId,
         type: activeType,
@@ -101,7 +108,7 @@ export const SongPage: FC = () => {
   return (
     <div className="max-w-2xl mx-auto px-4 py-6 flex flex-col gap-4">
       <a
-        href="/search"
+        href={`/search?locale=${locale}`}
         onClick={(e) => {
           if (window.history.length > 1 && document.referrer.startsWith(window.location.origin)) {
             e.preventDefault()
@@ -116,8 +123,10 @@ export const SongPage: FC = () => {
       </a>
 
       {headerSheet && <SongHeader sheet={headerSheet} />}
+      {headerSheet && <SongChartSummary sheet={headerSheet} />}
 
       <SongSheetTabs
+        songId={song.songId}
         sheets={song.sheets}
         availableTypes={availableTypes}
         activeType={activeType}

--- a/apps/web/src/pages/__tests__/SongPage.test.tsx
+++ b/apps/web/src/pages/__tests__/SongPage.test.tsx
@@ -1,5 +1,6 @@
 import { DifficultyEnum, VersionEnum } from '@gekichumai/dxdata'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import i18n from 'i18next'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { initI18n } from '@/setup/init-i18n'
 import { SongPage } from '../SongPage'
@@ -32,10 +33,6 @@ vi.mock('@/components/song/SongHeader', () => ({
   SongHeader: ({ sheet }: { sheet: { title: string } }) => <h1>{sheet.title}</h1>,
 }))
 
-vi.mock('@/components/song/SongSheetTabs', () => ({
-  SongSheetTabs: () => <nav aria-label="Sheet tabs" />,
-}))
-
 vi.mock('@/components/song/SongSheetContent', () => ({
   SongSheetContent: ({ sheet }: { sheet: { difficulty: string } }) => (
     <section data-testid="sheet-content">{sheet.difficulty}</section>
@@ -47,7 +44,9 @@ describe('SongPage', () => {
     initI18n()
   })
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    routeState.navigate.mockClear()
+    await i18n.changeLanguage('en')
     document.head.innerHTML = '<title>Route-owned title</title>'
   })
 
@@ -62,6 +61,21 @@ describe('SongPage', () => {
   it('uses search as the client fallback for the back link', () => {
     const { container } = render(<SongPage />)
 
-    expect(container.querySelector('a')?.getAttribute('href')).toBe('/search')
+    expect(container.querySelector('a')?.getAttribute('href')).toBe('/search?locale=en')
+  })
+
+  it('preserves the selected language when changing chart difficulty or type', async () => {
+    await i18n.changeLanguage('ja')
+    const { container } = render(<SongPage />)
+
+    expect(container.querySelector('a')?.getAttribute('href')).toBe('/search?locale=ja')
+    fireEvent.click(screen.getByRole('tab', { name: 'EXPERT' }))
+    fireEvent.click(screen.getByRole('tab', { name: 'でらっくす譜面' }))
+
+    expect(routeState.navigate).toHaveBeenCalledTimes(2)
+    for (const [destination] of routeState.navigate.mock.calls) {
+      expect(destination.search()).toEqual({ locale: 'ja' })
+    }
+    expect(routeState.navigate.mock.calls[0][0].params.difficulty).toBe(DifficultyEnum.Expert)
   })
 })

--- a/apps/web/src/routes/__tests__/-sitemap.test.ts
+++ b/apps/web/src/routes/__tests__/-sitemap.test.ts
@@ -1,8 +1,21 @@
 import { DifficultyEnum, TypeEnum } from '@gekichumai/dxdata'
 import { describe, expect, it } from 'vitest'
+import { SUPPORTED_LOCALES } from '@/setup/locale'
 import { buildSitemap } from '../sitemap[.]xml'
 
 describe('buildSitemap', () => {
+  it('publishes each supported locale as a canonical sitemap URL', () => {
+    const xml = new DOMParser().parseFromString(buildSitemap([]), 'application/xml')
+    expect(xml.querySelector('parsererror')).toBeNull()
+    const urls = Array.from(xml.getElementsByTagName('loc'), (entry) => entry.textContent)
+    expect(urls).toHaveLength(5 * SUPPORTED_LOCALES.length)
+    expect(new Set(urls).size).toBe(urls.length)
+    for (const locale of SUPPORTED_LOCALES) {
+      expect(urls).toContain(`https://dxrating.net/rating?locale=${locale}`)
+      expect(urls).toContain(`https://dxrating.net/search?locale=${locale}`)
+    }
+    expect(urls).not.toContain('https://dxrating.net/')
+  })
   it('encodes song URLs for route and XML safety', () => {
     const sitemap = buildSitemap([
       {
@@ -12,12 +25,12 @@ describe('buildSitemap', () => {
     ])
 
     expect(sitemap).toContain(
-      '<loc>https://dxrating.net/songs/1%2F3%E3%81%AE%E7%B4%94%E6%83%85%E3%81%AA%E6%84%9F%E6%83%85%20%26%20%3Ctest%3E/dx/master</loc>',
+      '<loc>https://dxrating.net/songs/1%2F3%E3%81%AE%E7%B4%94%E6%83%85%E3%81%AA%E6%84%9F%E6%83%85%20%26%20%3Ctest%3E/dx/master?locale=en</loc>',
     )
-    expect(sitemap).toContain('<loc>https://dxrating.net/charts/recent</loc>')
-    expect(sitemap).toContain('<loc>https://dxrating.net/charts/trending</loc>')
-    expect(sitemap).toContain('<loc>https://dxrating.net/developers</loc>')
-    expect(sitemap).not.toContain('<loc>https://dxrating.net/1/3の純情な感情 & <test>/dx/master</loc>')
+    expect(sitemap).toContain('<loc>https://dxrating.net/charts/recent?locale=en</loc>')
+    expect(sitemap).toContain('<loc>https://dxrating.net/charts/trending?locale=en</loc>')
+    expect(sitemap).toContain('<loc>https://dxrating.net/developers?locale=en</loc>')
+    expect(sitemap).not.toContain('<loc>https://dxrating.net/1/3の純情な感情 & <test>/dx/master?locale=en</loc>')
   })
 
   it('sorts sheet URLs by release date descending', () => {
@@ -55,9 +68,9 @@ describe('buildSitemap', () => {
       },
     ])
 
-    expect(sitemap).toContain('<loc>https://dxrating.net/songs/released/dx/master</loc>')
+    expect(sitemap).toContain('<loc>https://dxrating.net/songs/released/dx/master?locale=en</loc>')
     expect(sitemap).toContain('<lastmod>2026-05-10</lastmod>')
-    expect(sitemap).toContain('<loc>https://dxrating.net/songs/undated/dx/basic</loc>')
+    expect(sitemap).toContain('<loc>https://dxrating.net/songs/undated/dx/basic?locale=en</loc>')
     expect(sitemap).not.toContain('<lastmod>undefined</lastmod>')
   })
 })

--- a/apps/web/src/routes/rating.tsx
+++ b/apps/web/src/routes/rating.tsx
@@ -1,9 +1,14 @@
-import { createFileRoute } from '@tanstack/react-router'
-import { RatingCalculator } from '@/pages/RatingCalculator'
+import { ClientOnly, createFileRoute } from '@tanstack/react-router'
+import { lazy, Suspense } from 'react'
+import { RatingIntroduction, RatingLoading } from '@/components/rating/RatingIntroduction'
 import { buildRatingSeo, resolveSeoLocale } from '@/utils/seo'
 
+const RatingCalculator = lazy(() =>
+  import('@/pages/RatingCalculator').then((module) => ({ default: module.RatingCalculator })),
+)
+
 export const Route = createFileRoute('/rating')({
-  ssr: false,
+  ssr: true,
   head: ({ match, matches }) => {
     const seo = buildRatingSeo(resolveSeoLocale([match, ...matches]))
 
@@ -12,5 +17,20 @@ export const Route = createFileRoute('/rating')({
       links: seo.links,
     }
   },
-  component: RatingCalculator,
+  component: RatingPage,
 })
+
+function RatingPage() {
+  return (
+    <main>
+      <RatingIntroduction />
+      <div id="rating-calculator" className="scroll-mt-4" tabIndex={-1}>
+        <ClientOnly fallback={<RatingLoading />}>
+          <Suspense fallback={<RatingLoading />}>
+            <RatingCalculator />
+          </Suspense>
+        </ClientOnly>
+      </div>
+    </main>
+  )
+}

--- a/apps/web/src/routes/sitemap[.]xml.ts
+++ b/apps/web/src/routes/sitemap[.]xml.ts
@@ -1,8 +1,8 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { type DifficultyEnum, type TypeEnum, dxdata } from '@gekichumai/dxdata'
 import { buildSheetPath } from '@/components/sheet/sheetLinks'
-
-const BASE_URL = 'https://dxrating.net'
+import { buildLocalizedUrl } from '@/utils/alternateLinks'
+import { SUPPORTED_LOCALES } from '@/setup/locale'
 
 type SitemapSong = {
   songId: string
@@ -21,9 +21,21 @@ const escapeXml = (value: string) =>
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&apos;')
 
-const urlLoc = (path: string) => escapeXml(`${BASE_URL}${path}`)
-
-const lastmodXml = (releaseDate?: string) => (releaseDate ? `\n    <lastmod>${escapeXml(releaseDate)}</lastmod>` : '')
+// HTML heads own reciprocal hreflang links; the sitemap lists every canonical locale URL.
+const localizedUrlEntries = (path: string, changefreq: string, priority: number, releaseDate?: string) =>
+  SUPPORTED_LOCALES.map(
+    (locale) => `
+  <url>
+    <loc>${escapeXml(buildLocalizedUrl({ pathname: path }, locale))}</loc>${
+      releaseDate
+        ? `
+    <lastmod>${escapeXml(releaseDate)}</lastmod>`
+        : ''
+    }
+    <changefreq>${changefreq}</changefreq>
+    <priority>${priority}</priority>
+  </url>`,
+  ).join('')
 
 export function buildSitemap(songs: SitemapSong[]) {
   const sheetEntries = songs
@@ -34,54 +46,18 @@ export function buildSitemap(songs: SitemapSong[]) {
       })),
     )
     .sort((a, b) => (b.sheet.releaseDate ?? '').localeCompare(a.sheet.releaseDate ?? ''))
-    .map(
-      ({ songId, sheet }) => `
-  <url>
-    <loc>${urlLoc(
-      buildSheetPath({
-        songId,
-        type: sheet.type,
-        difficulty: sheet.difficulty,
-      }),
-    )}</loc>${lastmodXml(sheet.releaseDate)}
-	    <changefreq>monthly</changefreq>
-	    <priority>0.7</priority>
-	  </url>`,
+    .map(({ songId, sheet }) =>
+      localizedUrlEntries(
+        buildSheetPath({ songId, type: sheet.type, difficulty: sheet.difficulty }),
+        'monthly',
+        0.7,
+        sheet.releaseDate,
+      ),
     )
     .join('')
 
   return `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>${urlLoc('/')}</loc>
-    <changefreq>daily</changefreq>
-    <priority>1.0</priority>
-  </url>
-  <url>
-    <loc>${urlLoc('/search')}</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>${urlLoc('/charts/recent')}</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>${urlLoc('/charts/trending')}</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
-    <loc>${urlLoc('/rating')}</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>${urlLoc('/developers')}</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>${sheetEntries}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${localizedUrlEntries('/search', 'daily', 0.9)}${localizedUrlEntries('/charts/recent', 'daily', 0.9)}${localizedUrlEntries('/charts/trending', 'daily', 0.9)}${localizedUrlEntries('/rating', 'weekly', 0.8)}${localizedUrlEntries('/developers', 'weekly', 0.8)}${sheetEntries}
 </urlset>`
 }
 

--- a/apps/web/src/utils/__tests__/alternateLinks.test.ts
+++ b/apps/web/src/utils/__tests__/alternateLinks.test.ts
@@ -26,6 +26,14 @@ describe('buildLocalizedUrl', () => {
 })
 
 describe('buildAlternateLinks', () => {
+  it('keeps search language alternatives on the canonical landing pages', () => {
+    const links = buildAlternateLinks({
+      pathname: '/search',
+      search: { q: 'private query', songId: 'song', locale: 'ja' },
+    })
+    expect(links.find((link) => link.hrefLang === 'ja')?.href).toBe('https://dxrating.net/search?locale=ja')
+    expect(links.every((link) => !link.href?.includes('q='))).toBe(true)
+  })
   it('builds alternate links for the current route instead of the homepage', () => {
     expect(buildAlternateLinks({ pathname: '/songs/song-1', search: { type: 'dx' } })).toEqual([
       {

--- a/apps/web/src/utils/__tests__/rootHeadLinks.test.ts
+++ b/apps/web/src/utils/__tests__/rootHeadLinks.test.ts
@@ -13,13 +13,13 @@ describe('buildRootHeadLinks', () => {
     )
   })
 
-  it('retains the current-route alternate links', () => {
+  it('publishes canonical search landing pages as language alternatives', () => {
     const links = buildRootHeadLinks({ pathname: '/search', search: { q: '宴' } })
 
     expect(links).toContainEqual({
       rel: 'alternate',
       hrefLang: 'ja',
-      href: 'https://dxrating.net/search?q=%E5%AE%B4&locale=ja',
+      href: 'https://dxrating.net/search?locale=ja',
     })
   })
 

--- a/apps/web/src/utils/__tests__/seo.test.ts
+++ b/apps/web/src/utils/__tests__/seo.test.ts
@@ -1,8 +1,14 @@
 import { CategoryEnum, DifficultyEnum, TypeEnum, VersionEnum } from '@gekichumai/dxdata'
 import { describe, expect, it } from 'vitest'
+import { createServerI18n } from '@/setup/init-i18n'
+import { SUPPORTED_LOCALES } from '@/setup/locale'
+import { buildAlternateLinks } from '../alternateLinks'
 import {
   buildDevelopersSeo,
   buildRootSeoMeta,
+  buildRatingSeo,
+  buildRecentChartsSeo,
+  buildTrendingChartsSeo,
   buildSearchSeo,
   buildSongSheetSeo,
   buildSongSheetStructuredData,
@@ -10,6 +16,31 @@ import {
 } from '../seo'
 
 describe('SEO localization', () => {
+  it.each(SUPPORTED_LOCALES)('aligns canonical and language alternates for %s', (locale) => {
+    for (const [path, build] of [
+      ['/search', buildSearchSeo],
+      ['/rating', buildRatingSeo],
+      ['/developers', buildDevelopersSeo],
+      ['/charts/recent', buildRecentChartsSeo],
+      ['/charts/trending', buildTrendingChartsSeo],
+    ] as const) {
+      const alternate = buildAlternateLinks({ pathname: path }).find((link) => link.hrefLang === locale)
+      const seo = build(locale)
+      expect(seo.links).toContainEqual({ rel: 'canonical', href: alternate?.href })
+      expect(seo.meta).toContainEqual({ property: 'og:url', content: alternate?.href })
+    }
+  })
+
+  it('includes a known BPM in song metadata without inventing missing values', () => {
+    const song = { title: 'Song', artist: 'Artist', category: 'maimai', imageName: 'song', songId: 'a/b & c' }
+    const sheet = { type: TypeEnum.DX, difficulty: DifficultyEnum.Master }
+    expect(buildSongSheetSeo({ ...song, bpm: 180 }, sheet, 'en').description).toContain('180 BPM')
+    expect(buildSongSheetSeo({ ...song, bpm: null }, sheet, 'en').description).not.toMatch(/null|undefined|BPM/)
+    expect(buildSongSheetSeo(song, sheet, 'ja').links).toContainEqual({
+      rel: 'canonical',
+      href: 'https://dxrating.net/songs/a%2Fb%20%26%20c/dx/master?locale=ja',
+    })
+  })
   it('resolves the locale from route server context before falling back to English', () => {
     expect(
       resolveSeoLocale([
@@ -38,18 +69,17 @@ describe('SEO localization', () => {
   })
 
   it('builds localized search route metadata', () => {
-    expect(buildSearchSeo('ja').title).toBe('譜面検索 - DXRating')
-    expect(buildSearchSeo('ja').description).toBe(
-      'maimai DX の譜面を、楽曲名、アーティスト、難易度から検索できます。譜面定数、ノーツ数、詳しい譜面情報も確認できます。',
-    )
+    const i18n = createServerI18n('ja')
+    expect(buildSearchSeo('ja').title).toBe(`${i18n.t('root:pages.search.seo-title')} - DXRating`)
+    expect(buildSearchSeo('ja').description).toBe(i18n.t('root:pages.search.seo-description'))
   })
 
   it('builds localized developer API metadata', () => {
     const seo = buildDevelopersSeo('ja')
 
     expect(seo.title).toBe('開発者向け API - DXRating')
-    expect(seo.links).toContainEqual({ rel: 'canonical', href: 'https://dxrating.net/developers' })
-    expect(seo.meta).toContainEqual({ property: 'og:url', content: 'https://dxrating.net/developers' })
+    expect(seo.links).toContainEqual({ rel: 'canonical', href: 'https://dxrating.net/developers?locale=ja' })
+    expect(seo.meta).toContainEqual({ property: 'og:url', content: 'https://dxrating.net/developers?locale=ja' })
   })
 
   it('builds localized song sheet title and social metadata', () => {
@@ -68,8 +98,14 @@ describe('SEO localization', () => {
       'zh-Hant',
     )
 
-    expect(seo.title).toBe('Test Song [標準 MASTER] - DXRating')
-    expect(seo.description).toBe('Test Song / Test Artist - 標準 MASTER 譜面詳情、譜面定數與音符數 - DXRating。')
+    expect(seo.title).toBe('Test Song [標準 MASTER] - maimai - DXRating')
+    expect(seo.description).toBe(
+      createServerI18n('zh-Hant').t('song:seo.description', {
+        title: 'Test Song',
+        artist: 'Test Artist',
+        sheetLabel: '標準 MASTER',
+      }),
+    )
     expect(seo.meta).toContainEqual({ property: 'og:title', content: seo.title })
     expect(seo.meta).toContainEqual({
       property: 'og:image',
@@ -139,7 +175,7 @@ describe('SEO localization', () => {
         expect.objectContaining({
           '@type': 'Dataset',
           name: 'Test Song DX MASTER chart',
-          url: 'https://dxrating.net/songs/test-song/dx/master',
+          url: 'https://dxrating.net/songs/test-song/dx/master?locale=en',
           datePublished: '2026-05-10',
           additionalProperty: expect.arrayContaining([
             expect.objectContaining({ name: 'Chart type', value: 'DX' }),

--- a/apps/web/src/utils/alternateLinks.ts
+++ b/apps/web/src/utils/alternateLinks.ts
@@ -44,11 +44,11 @@ export const buildAlternateLinks = (location: AlternateLinkLocation): AlternateL
   {
     rel: 'alternate',
     hrefLang: 'x-default',
-    href: buildLocalizedUrl(location),
+    href: buildLocalizedUrl(location.pathname === '/search' ? { pathname: location.pathname } : location),
   },
   ...SUPPORTED_LOCALES.map((locale) => ({
     rel: 'alternate',
     hrefLang: locale,
-    href: buildLocalizedUrl(location, locale),
+    href: buildLocalizedUrl(location.pathname === '/search' ? { pathname: location.pathname } : location, locale),
   })),
 ]

--- a/apps/web/src/utils/seo.ts
+++ b/apps/web/src/utils/seo.ts
@@ -2,7 +2,8 @@ import { TypeEnum, type DifficultyEnum, type NoteCounts, type Regions, type Shee
 import type { SupportedLocale } from '@/setup/locale'
 import { DEFAULT_LOCALE, toSupportedLocale } from '@/setup/locale'
 import { createServerI18n } from '@/setup/init-i18n'
-import { buildSheetLink } from '@/components/sheet/sheetLinks'
+import { buildSheetPath } from '@/components/sheet/sheetLinks'
+import { buildLocalizedUrl } from './alternateLinks'
 import { getSheetPageTitle, getSheetTitleLabel, getSheetTypeDisplayName } from '@/components/song/sheetDisplay'
 import { buildChartOgImageAlt, buildChartOgImageUrl } from '@/routes/-chart-og-meta'
 
@@ -113,6 +114,7 @@ export function buildRootSeoMeta(locale: SupportedLocale, options: { includeTitl
 }
 
 export function buildSearchSeo(locale: SupportedLocale) {
+  const url = buildLocalizedUrl({ pathname: '/search' }, locale)
   const title = formatSeoTitle(t(locale, 'root:pages.search.seo-title'))
   const description = t(locale, 'root:pages.search.seo-description')
 
@@ -124,18 +126,19 @@ export function buildSearchSeo(locale: SupportedLocale) {
       { name: 'description', content: description },
       { property: 'og:title', content: title },
       { property: 'og:description', content: description },
-      { property: 'og:url', content: 'https://dxrating.net/search' },
+      { property: 'og:url', content: url },
       { property: 'og:type', content: 'website' },
       { property: 'og:locale', content: OG_LOCALES[locale] },
       { name: 'twitter:card', content: 'summary' },
       { name: 'twitter:title', content: title },
       { name: 'twitter:description', content: description },
     ] satisfies SeoMeta[],
-    links: [{ rel: 'canonical', href: 'https://dxrating.net/search' }],
+    links: [{ rel: 'canonical', href: url }],
   }
 }
 
 export function buildDevelopersSeo(locale: SupportedLocale) {
+  const url = buildLocalizedUrl({ pathname: '/developers' }, locale)
   const title = formatSeoTitle(t(locale, 'developers:seo-title'))
   const description = t(locale, 'developers:seo-description')
 
@@ -147,18 +150,19 @@ export function buildDevelopersSeo(locale: SupportedLocale) {
       { name: 'description', content: description },
       { property: 'og:title', content: title },
       { property: 'og:description', content: description },
-      { property: 'og:url', content: 'https://dxrating.net/developers' },
+      { property: 'og:url', content: url },
       { property: 'og:type', content: 'website' },
       { property: 'og:locale', content: OG_LOCALES[locale] },
       { name: 'twitter:card', content: 'summary' },
       { name: 'twitter:title', content: title },
       { name: 'twitter:description', content: description },
     ] satisfies SeoMeta[],
-    links: [{ rel: 'canonical', href: 'https://dxrating.net/developers' }],
+    links: [{ rel: 'canonical', href: url }],
   }
 }
 
 export function buildRecentChartsSeo(locale: SupportedLocale) {
+  const url = buildLocalizedUrl({ pathname: '/charts/recent' }, locale)
   const title = formatSeoTitle(t(locale, 'root:pages.recent.seo-title'))
   const description = t(locale, 'root:pages.recent.seo-description')
 
@@ -170,18 +174,19 @@ export function buildRecentChartsSeo(locale: SupportedLocale) {
       { name: 'description', content: description },
       { property: 'og:title', content: title },
       { property: 'og:description', content: description },
-      { property: 'og:url', content: 'https://dxrating.net/charts/recent' },
+      { property: 'og:url', content: url },
       { property: 'og:type', content: 'website' },
       { property: 'og:locale', content: OG_LOCALES[locale] },
       { name: 'twitter:card', content: 'summary' },
       { name: 'twitter:title', content: title },
       { name: 'twitter:description', content: description },
     ] satisfies SeoMeta[],
-    links: [{ rel: 'canonical', href: 'https://dxrating.net/charts/recent' }],
+    links: [{ rel: 'canonical', href: url }],
   }
 }
 
 export function buildTrendingChartsSeo(locale: SupportedLocale) {
+  const url = buildLocalizedUrl({ pathname: '/charts/trending' }, locale)
   const title = formatSeoTitle(t(locale, 'root:pages.trending.seo-title'))
   const description = t(locale, 'root:pages.trending.seo-description')
 
@@ -193,18 +198,19 @@ export function buildTrendingChartsSeo(locale: SupportedLocale) {
       { name: 'description', content: description },
       { property: 'og:title', content: title },
       { property: 'og:description', content: description },
-      { property: 'og:url', content: 'https://dxrating.net/charts/trending' },
+      { property: 'og:url', content: url },
       { property: 'og:type', content: 'website' },
       { property: 'og:locale', content: OG_LOCALES[locale] },
       { name: 'twitter:card', content: 'summary' },
       { name: 'twitter:title', content: title },
       { name: 'twitter:description', content: description },
     ] satisfies SeoMeta[],
-    links: [{ rel: 'canonical', href: 'https://dxrating.net/charts/trending' }],
+    links: [{ rel: 'canonical', href: url }],
   }
 }
 
 export function buildRatingSeo(locale: SupportedLocale) {
+  const url = buildLocalizedUrl({ pathname: '/rating' }, locale)
   const title = formatSeoTitle(t(locale, 'root:pages.rating.seo-title'))
   const description = t(locale, 'root:pages.rating.seo-description')
 
@@ -216,20 +222,21 @@ export function buildRatingSeo(locale: SupportedLocale) {
       { name: 'description', content: description },
       { property: 'og:title', content: title },
       { property: 'og:description', content: description },
-      { property: 'og:url', content: 'https://dxrating.net/rating' },
+      { property: 'og:url', content: url },
       { property: 'og:type', content: 'website' },
       { property: 'og:locale', content: OG_LOCALES[locale] },
       { name: 'twitter:card', content: 'summary' },
       { name: 'twitter:title', content: title },
       { name: 'twitter:description', content: description },
     ] satisfies SeoMeta[],
-    links: [{ rel: 'canonical', href: 'https://dxrating.net/rating' }],
+    links: [{ rel: 'canonical', href: url }],
   }
 }
 
 export function buildSongSheetSeo(
   song: {
     title: string
+    bpm?: number | null
     artist: string
     category: string
     imageName: string
@@ -243,11 +250,13 @@ export function buildSongSheetSeo(
 ) {
   const sheetLabel = getSheetTitleLabel(sheet, locale)
   const title = getSheetPageTitle(song, sheet, locale)
-  const description = t(locale, 'song:seo.description', {
+  const chartDescription = t(locale, 'song:seo.description', {
     title: song.title,
     artist: song.artist,
     sheetLabel,
   })
+  const description =
+    song.bpm && song.bpm > 0 ? `${chartDescription} ${t(locale, 'song:seo.bpm', { bpm: song.bpm })}` : chartDescription
   const image = `https://shama.dxrating.net/images/cover/v2/${song.imageName}.jpg`
   const socialImage = buildChartOgImageUrl({
     songId: song.songId,
@@ -260,13 +269,9 @@ export function buildSongSheetSeo(
     type: sheet.type,
     difficulty: sheet.difficulty,
   })
-  const url = buildSheetLink(
-    {
-      songId: song.songId,
-      type: sheet.type,
-      difficulty: sheet.difficulty,
-    },
-    'https://dxrating.net',
+  const url = buildLocalizedUrl(
+    { pathname: buildSheetPath({ songId: song.songId, type: sheet.type, difficulty: sheet.difficulty }) },
+    locale,
   )
 
   return {

--- a/docs/seo-opportunities-2026-09-05.md
+++ b/docs/seo-opportunities-2026-09-05.md
@@ -1,0 +1,26 @@
+# Search opportunity implementation
+
+## Changes
+
+- `/search`: localized maimai heading, description, calculator/recent/trending links, and ten catalog-backed song links on the empty-query landing page.
+- `/rating`: server-rendered Best 50 introduction and import/calculation/export guide; the interactive calculator stays behind a client boundary.
+- Song pages: compact BPM, chart constant, selected version and availability facts; clearer maimai titles; crawlable chart tabs that preserve locale and modified-click behavior.
+- Five supported languages: self-canonical URLs, matching Open Graph URLs and reciprocal HTML hreflang links. Search filters canonicalize to the localized search landing page.
+- Sitemap: canonical URLs for all five locales, excluding the redirecting homepage. HTML owns hreflang relationships; they are not duplicated in XML. These methods are equivalent under [Google's localized-page guidance](https://developers.google.com/search/docs/specialty/international/localized-versions).
+
+## Measurement after deployment
+
+Record the actual deployment date before interpreting results. Compare complete, matched 28-day search-performance windows before and after deployment, leaving time for recrawling. Keep query, page, device and country segments consistent; aggregate difficulty and locale variants into cohorts as well as inspecting individual URLs. Do not treat multiple URLs for a query as proof of cannibalization.
+
+Use this query set for comparison or keyword rank tracking:
+
+| Cohort | Queries | Intended destination |
+| --- | --- | --- |
+| Chart search | maimai charts; maimai chart; maimai song search | `/search` |
+| Calculator | maimai rating calculator; maimai rating; maimai rating 計算 | `/rating` |
+| Best 50 | maimai b50; maimai b50 查詢 | `/rating` |
+| Song details | latent kingdom; クロノイデア; 終焉逃避行 bpm; 7 wonders maimai; regulus maimai; sky trails maimai; 雨露霜雪 | Corresponding song chart pages |
+
+Check clicks, impressions, CTR and average position alongside existing organic-arrival import/calculator/export completion events. Inspect Google-selected canonicals for English, Japanese and Traditional Chinese search/rating/song samples. Run a site crawl after deployment to validate production rendering, canonical targets and internal links.
+
+No deployment or external monitoring configuration is performed by this code change.


### PR DESCRIPTION
Search and rating landing pages need useful crawlable content, and localized pages currently advertise locale-free canonicals. This adds maimai-focused introductions and links, server-renders the Best 50 guide while keeping the calculator interactive, and makes song facts and difficulty links easier to discover.

- Translate the new content into all five supported languages.
- Align canonical, Open Graph and hreflang URLs; include each localized canonical in the sitemap.
- Preserve the selected language during chart navigation and support keyboard and modified-click link activation.
- Document query cohorts and post-deployment measurement steps without changing external monitoring configuration.

Validation: 187 web tests pass; production build and TypeScript checks pass; lint reports no errors (24 existing warnings). Japanese and Traditional Chinese production-preview checks confirmed no hydration errors, keyboard navigation preserves locale, and a stored sample score survives reload with the expected rating. Desktop/mobile layouts and sitemap XML were also checked.
